### PR TITLE
feat(gitbook): canonical linkの設定とGitBook.comビルドについてを追記

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,21 @@
 4. Pushする: `git push origin my-new-feature`
 5. Pull Requestを送る :D
 
+## 確認方法
+
+`npm start`を実行後、 [http://localhost:4000/](http://localhost:4000/) へアクセスすることでプレビューを見られます。
+
+    npm run start
+    # open http://localhost:4000/
+
+また、Pull Requestを出した際にGitBook.com上でプレビュー用のビルドが公開されます。
+Pull Request下部に表示されるCI Statusからそれぞれプレビュービルドひらくことができます。
+
+![CI Status](https://cloud.githubusercontent.com/assets/19714/16651848/a221c226-4481-11e6-806f-65880da93422.png)
+
+- [プレビュー用 #jsprimer - GitBook](https://www.gitbook.com/book/azu/js-primer/details "プレビュー用 #jsprimer - GitBook")
+    - プレビュー以外には利用しないでください
+
 ## テスト
 
 `$ npm test` を実行するとコードや文章に対するテストを実行できます。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
     # open http://localhost:4000/
 
 また、Pull Requestを出した際にGitBook.com上でプレビュー用のビルドが公開されます。
-Pull Request下部に表示されるCI Statusからそれぞれプレビュービルドひらくことができます。
+Pull Request下部に表示されるCI Statusからそれぞれプレビュービルドを見ることができます。
 
 ![CI Status](https://cloud.githubusercontent.com/assets/19714/16651848/a221c226-4481-11e6-806f-65880da93422.png)
 

--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "gitbook": ">=2.5.2",
+  "gitbook": ">=3.0.0",
   "title": "JavaScriptの入門書 #jsprimer",
   "description": "この書籍はES2015以降をベースとしたJavaScript入門書となる予定",
   "root": "./source/",

--- a/book.json
+++ b/book.json
@@ -10,12 +10,16 @@
   "plugins": [
     "include-codeblock",
     "japanese-support",
-    "edit-link"
+    "edit-link",
+    "canonical-link"
   ],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/asciidwango/js-primer/edit/master/source/",
       "label": "Edit"
+    },
+    "canonical-link": {
+      "baseURL": "https://asciidwango.github.io/js-primer"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^3.0.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "gitbook-cli": "^2.1.2",
+    "gitbook-plugin-canonical-link": "^2.0.2",
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-include-codeblock": "^1.4.0",
     "gitbook-plugin-japanese-support": "0.0.1",


### PR DESCRIPTION
https://github.com/azu/gitbook-plugin-canonical-link を使って `<link rel="canonical" >`を付けるようにしました。

目的としてはGitBook.comのプレビュー用のビルドを見えるようにするためです。
以下にプレビュー用に自動ビルドされているGitBookが公開されています。
Pull Requestごとにプレビューを見ることができます。

- https://www.gitbook.com/book/azu/js-primer/details

ビルドしたHTMLには  `<link rel="canonical" >` でGitHub Pages版を参照するようにしているので、Google検索的にも大丈夫になっていると思います。