### PR TITLE
fix(gitbook): 複数行のコードブロックが改行しなくなる問題を修正

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,6 @@
   },
   "plugins": [
     "include-codeblock",
-    "japanese-support",
     "edit-link",
     "canonical-link",
     "ga"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-ga": "^1.0.1",
     "gitbook-plugin-include-codeblock": "^1.4.0",
-    "gitbook-plugin-japanese-support": "0.0.1",
     "gitbook-summary-to-path": "^1.0.1",
     "globby": "^5.0.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
"japanese-support"が改行を削っていた

close https://github.com/asciidwango/js-primer/issues/105