### PR TITLE
fix(loop): サロゲートペアの記述を削除

### DIFF
--- a/source/basic/loop/README.md
+++ b/source/basic/loop/README.md
@@ -327,7 +327,7 @@ for...in文とは異なり、添字ではなく値を列挙します。
 [import, for-of-array-example.js](./src/for-of/for-of-array-example.js)
 
 JavaScriptではStringオブジェクトもiterableです。
-サロゲートペアも考慮し、文字列を1文字ずつ列挙することができます。
+そのため、文字列を1文字ずつ列挙することができます。
 
 {{book.console}}
 [import, for-of-string-example.js](./src/for-of/for-of-string-example.js)


### PR DESCRIPTION
多分、 http://teppeis.hatenablog.com/entry/2014/01/surrogate-pair-in-javascript この辺の話が書きたかったのだと思う。
しかし、現在の記述は間違っているので削除する。

書き直すと思うので、Issueはそのまま残しておきます。

refs: #106