### PR TITLE
chore(travis): Node.js LTSとstableに固定

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
-node_js: stable
+node_js:
+- 'stable'
+- 'lts/*'
 # gh-pagesへのdeploy向け
 env:
   global:
@@ -14,6 +16,9 @@ after_success:
     $(npm bin)/set-up-ssh --key "$encrypted_55887fb399d9_key" \
                           --iv "$encrypted_55887fb399d9_iv" \
                           --path-encrypted-key ".travis/github_deploy_key.enc"
+
+    # https://github.com/alrra/travis-scripts/blob/master/doc/handle-multiple-jobs.md
+    $(npm bin)/travis-after-all && \
     $(npm bin)/update-branch --commands "npm run build" \
                              --commit-message "Deploy GitBook build [skip ci]" \
                              --directory "_book" \

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "textlint-rule-no-js-function-paren": "^1.0.1",
     "textlint-rule-preset-ja-technical-writing": "^0.1.1",
     "textlint-rule-prh": "^3.0.1",
+    "travis-after-all": "^1.4.4",
     "unist-util-select": "^1.5.0"
   },
   "dependencies": {}


### PR DESCRIPTION
`travis-after-all`を使って複数ビルドを待つように

close #160