### PR TITLE
Fix variable name

### DIFF
--- a/source/basic/loop/README.md
+++ b/source/basic/loop/README.md
@@ -134,7 +134,7 @@ array.forEach(コールバック関数);
 {{book.console}}
 ```js
 [1, 2, 3].forEach(currentValue => {
-    console.log(num);
+    console.log(currentValue);
 });
 // 1
 // 2


### PR DESCRIPTION
代入される変数を適切なものに変更した

配列の値をcurrentValueに代入しなければ、ログを出せないのに、numという定義してない変数に代入しようとしていて、`ReferenceError: num is not defined`が出ていたので修正した