### PR TITLE
fix(website): fix docSearch plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -10,7 +10,7 @@
   "plugins": [
     "-search",
     "-lunr",
-    "docsearch",
+    "docsearch-temp",
     "include-codeblock",
     "anchors",
     "edit-link",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gitbook-cli": "^2.1.2",
     "gitbook-plugin-anchors": "^0.7.1",
     "gitbook-plugin-canonical-link": "^2.0.2",
-    "gitbook-plugin-docsearch": "github:azu/gitbook-plugin-docsearch",
+    "gitbook-plugin-docsearch-temp": "^1.1.3",
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-ga": "^1.0.0",
     "gitbook-plugin-github-issue-feedback": "^1.1.1",


### PR DESCRIPTION
GItBookによってpacakge.jsonは無視されて、npmの本家(バグってる)が参照されていた。