### PR TITLE
fix(usecase/nodecli): gfmオプションをデフォルトでfalseにする

### DIFF
--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -98,6 +98,7 @@ const program = require("commander");
 ```
 
 commanderは`parse`メソッドを使ってコマンドライン引数をパースします。
+パースした後に`opts`メソッドを呼び出すと、定義したオプションと与えられた値をマップオブジェクトとして取り出すことができます。
 次の`commander-flag.js`では、値をもたないオプションを真偽値にパースしています。
 
 [import commander-flag.js](src/commander-flag.js)

--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -102,7 +102,7 @@ commanderは`parse`メソッドを使ってコマンドライン引数をパー�
 
 [import commander-flag.js](src/commander-flag.js)
 
-このスクリプトを次のように実行すると、`--foo`オプションがパースされ、`program.foo`プロパティとして扱えるようになっています。
+このスクリプトを次のように実行すると、`--foo`オプションがパースされ、`options.foo`プロパティとして扱えるようになっています。
 
 ```shell-session
 $ node commander-flag.js --foo
@@ -120,7 +120,7 @@ Error: Cannot find module 'commander'
 
 [import commander-param.js](src/commander-param.js)
 
-`--foo`オプションに値を与えて実行すれば、文字列が`program.foo`プロパティにセットされていることがわかります。
+`--foo`オプションに値を与えて実行すれば、文字列が`options.foo`プロパティにセットされていることがわかります。
 
 ```shell-session
 $ node commander-param.js --foo bar

--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -98,7 +98,7 @@ const program = require("commander");
 ```
 
 commanderは`parse`メソッドを使ってコマンドライン引数をパースします。
-パースした後に`opts`メソッドを呼び出すと、定義したオプションと与えられた値をマップオブジェクトとして取り出すことができます。
+パースした後に`opts`メソッドを呼び出すと、定義したオプションと与えられた値をオブジェクトとして取り出すことができます。
 次の`commander-flag.js`では、値をもたないオプションを真偽値にパースしています。
 
 [import commander-flag.js](src/commander-flag.js)

--- a/source/use-case/nodecli/argument-parse/src/commander-flag.js
+++ b/source/use-case/nodecli/argument-parse/src/commander-flag.js
@@ -1,4 +1,5 @@
 const program = require("commander");
 program.option("--foo");
 program.parse(process.argv);
-console.log(program.foo);
+const options = program.opts();
+console.log(options.foo);

--- a/source/use-case/nodecli/argument-parse/src/commander-param.js
+++ b/source/use-case/nodecli/argument-parse/src/commander-param.js
@@ -1,4 +1,5 @@
 const program = require("commander");
 program.option("--foo <text>");
 program.parse(process.argv);
-console.log(program.foo);
+const options = program.opts();
+console.log(options.foo);

--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -120,8 +120,8 @@ https://asciidwango.github.io/js-primer/</p>
 <!-- doctest:disable -->
 ```js
 program
-    .option("--gfm <flag>", "GFMを有効にする")
-    .option("-S, --sanitize <flag>", "サニタイズを行う");
+    .option("--gfm", "GFMを有効にする")
+    .option("-S, --sanitize", "サニタイズを行う");
 
 program.parse(process.argv);
 ```
@@ -129,8 +129,8 @@ program.parse(process.argv);
 ### デフォルト設定を定義する {#declare-default}
 
 毎回すべての設定を明示的に入力させるのは不便なので、それぞれの変換オプションのデフォルト設定を定義します。
-今回は`gfm`オプションを`true`、`sanitize`オプションを`false`にします。
-markedのデフォルト設定と同じですが、アプリケーション側でデフォルト設定を持っておくことで、将来的にmarkedの挙動が変わったときにも影響を受けにくくなります。
+今回は`gfm`オプションと`sanitize`オプションをどちらもデフォルトで`false`にします。
+アプリケーション側でデフォルト設定を持っておくことで、将来的にmarkedの挙動が変わったときにも影響を受けにくくなります。
 
 markedのオプションはオブジェクトを渡す形式です。
 オブジェクトのデフォルト値を明示的な値で上書きするときにはspreadプロパティを使うと便利です。([オブジェクトのコピー・マージ](../../../basic/object/README.md#copy-and-merge)を参照)
@@ -140,7 +140,7 @@ markedのオプションはオブジェクトを渡す形式です。
 <!-- doctest:disable -->
 ```js
 const markedOptions = {
-    gfm: true,
+    gfm: false,
     sanitize: false,
     ...program
 };
@@ -154,8 +154,10 @@ const markedOptions = {
 定義したコマンドライン引数を使って、Markdownファイルを変換してみましょう。
 
 ```shell-session
-$ node main.js --gfm false sample.md
-$ node main.js -S true sample.md
+# gfmオプションを有効にする
+$ node main.js --gfm sample.md
+# sanitizeオプションを短縮形で有効にする
+$ node main.js -S sample.md
 ```
 
 これでMarkdown変換の設定をコマンドライン引数でオプションとして与えられるようになりました。

--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -134,7 +134,7 @@ program.parse(process.argv);
 
 markedのオプションはオブジェクトを渡す形式です。
 オブジェクトのデフォルト値を明示的な値で上書きするときにはspreadプロパティを使うと便利です。([オブジェクトのコピー・マージ](../../../basic/object/README.md#copy-and-merge)を参照)
-次のようにデフォルトのオプションを表現したオブジェクトに対して、コマンドライン引数をパースして得られたオブジェクトを上書きします。
+次のようにデフォルトのオプションを表現したオブジェクトに対して、`program.opts`メソッドの戻り値で上書きします。
 
 <!-- 差分コードなので -->
 <!-- doctest:disable -->
@@ -142,7 +142,8 @@ markedのオプションはオブジェクトを渡す形式です。
 const markedOptions = {
     gfm: false,
     sanitize: false,
-    ...program
+    // オプションのkey-valueオブジェクトをマージする
+    ...program.opts()
 };
 ```
 

--- a/source/use-case/nodecli/md-to-html/src/main-4.js
+++ b/source/use-case/nodecli/md-to-html/src/main-4.js
@@ -3,14 +3,14 @@ const fs = require("fs");
 const marked = require("marked");
 
 program
-    .option("--gfm <flag>", "GFMを有効にする")
-    .option("-S, --sanitize <flag>", "サニタイズを行う");
+    .option("--gfm", "GFMを有効にする")
+    .option("-S, --sanitize", "サニタイズを行う");
 
 program.parse(process.argv);
 const filePath = program.args[0];
 
 const markedOptions = {
-    gfm: true,
+    gfm: false,
     sanitize: false,
     ...program
 };

--- a/source/use-case/nodecli/md-to-html/src/main-4.js
+++ b/source/use-case/nodecli/md-to-html/src/main-4.js
@@ -12,7 +12,7 @@ const filePath = program.args[0];
 const markedOptions = {
     gfm: false,
     sanitize: false,
-    ...program
+    ...program.opts()
 };
 
 fs.readFile(filePath, "utf8", (err, file) => {

--- a/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
@@ -12,7 +12,7 @@ const filePath = program.args[0];
 const markedOptions = {
     gfm: false,
     sanitize: false,
-    ...program
+    ...program.opts()
 };
 
 fs.readFile(filePath, "utf8", (err, file) => {

--- a/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
@@ -3,16 +3,17 @@ const fs = require("fs");
 const marked = require("marked");
 
 program
-    .option("--gfm <flag>", "GFMを有効にする")
-    .option("-S, --sanitize <flag>", "サニタイズを行う");
+    .option("--gfm", "GFMを有効にする")
+    .option("-S, --sanitize", "サニタイズを行う");
 
 program.parse(process.argv);
 const filePath = program.args[0];
 
-const markedOptions = Object.assign({}, {
-    gfm: true,
-    sanitize: false
-}, program);
+const markedOptions = {
+    gfm: false,
+    sanitize: false,
+    ...program
+};
 
 fs.readFile(filePath, "utf8", (err, file) => {
     if (err) {

--- a/source/use-case/nodecli/refactor-and-unittest/src/main.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/main.js
@@ -15,6 +15,6 @@ fs.readFile(filePath, "utf8", (err, file) => {
         process.exit(err.code);
         return;
     }
-    const html = md2html(file, program);
+    const html = md2html(file, program.opts());
     console.log(html);
 });

--- a/source/use-case/nodecli/refactor-and-unittest/src/main.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/main.js
@@ -3,8 +3,8 @@ const fs = require("fs");
 const md2html = require("./md2html");
 
 program
-    .option("--gfm <flag>", "GFMを有効にする")
-    .option("-S, --sanitize <flag>", "サニタイズを行う");
+    .option("--gfm", "GFMを有効にする")
+    .option("-S, --sanitize", "サニタイズを行う");
 
 program.parse(process.argv);
 const filePath = program.args[0];

--- a/source/use-case/nodecli/refactor-and-unittest/src/md2html.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/md2html.js
@@ -1,10 +1,11 @@
 const marked = require("marked");
 
 module.exports = (markdown, options = {}) => {
-    const markedOptions = Object.assign({}, {
-        gfm: true,
-        sanitize: false
-    }, options);
+    const markedOptions = {
+        gfm: false,
+        sanitize: false,
+        ...options,
+    };
 
     return marked(markdown, {
         gfm: markedOptions.gfm,

--- a/source/use-case/nodecli/refactor-and-unittest/src/test/.editorconfig
+++ b/source/use-case/nodecli/refactor-and-unittest/src/test/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = false

--- a/source/use-case/nodecli/refactor-and-unittest/src/test/fixtures/expected.html
+++ b/source/use-case/nodecli/refactor-and-unittest/src/test/fixtures/expected.html
@@ -1,3 +1,3 @@
 <p>これはサンプルです。
-<a href="https://asciidwango.github.io/js-primer/">https://asciidwango.github.io/js-primer/</a></p>
+https://asciidwango.github.io/js-primer/</p>
 <p>これはHTMLです</p>


### PR DESCRIPTION
Fix #484