### PR TITLE
`numbers`に偶数が含まれていないならfalseを返す

### DIFF
--- a/source/basic/loop/src/break/find-even-break-example.js
+++ b/source/basic/loop/src/break/find-even-break-example.js
@@ -4,7 +4,7 @@ function isEven(number) {
 }
 // `numbers`に偶数が含まれているならtrueを返す
 function isEvenIncluded(numbers) {
-    let isEventIncluded;
+    let isEventIncluded = false;
     for (let i = 0; i < numbers.length; i++) {
         const number = numbers[i];
         if (isEven(number)) {


### PR DESCRIPTION
numbersに偶数が含まれていない場合、console.log()で`undefined`と表示されるのは、良くないと思いましたので、修正いたしました。いかがでしょうか？