### PR TITLE
chore(prh): prototypeオブジェクト -> プロトタイプオブジェクト

### DIFF
--- a/prh.yml
+++ b/prh.yml
@@ -269,6 +269,9 @@ rules:
   - expected: サーバーサイド
     patterns:
       - サーバサイド
+  - expected: プロトタイプオブジェクト
+    patterns:
+      - prototypeオブジェクト
 
   # 一致とマッチ
   ## 一致は ===


### PR DESCRIPTION
`prototype`オブジェクトはいいけど、prototypeオブジェクトは避けたいので。

用語統一の辞書