### PR TITLE
feat(doctest): standardize skipped code block

### DIFF
--- a/source/basic/async/README.md
+++ b/source/basic/async/README.md
@@ -199,7 +199,7 @@ try {
         throw new Error("非同期的なエラー");
     }, 10);
 } catch (error) {
-    console.log("この文は実行されません");
+    // この文は実行されません
 }
 console.log("この文は実行されます");
 ```
@@ -294,7 +294,7 @@ function dummyFetch(path, callback) {
 // /success/data にリソースが存在するので、`response`にはデータが入る
 dummyFetch("/success/data", (error, response) => {
     if (error) {
-        console.log(error); // この文は実行されません
+        // この文は実行されません
     } else {
         console.log(response); // => { body: "Response body of /success/data" }
     }
@@ -304,7 +304,7 @@ dummyFetch("/failure/data", (error, response) => {
     if (error) {
         console.log(error.message); // => "NOT FOUND"
     } else {
-        console.log(response); // この文は実行されません
+        // この文は実行されません
     }
 });
 ```
@@ -471,11 +471,11 @@ function dummyFetch(path) {
 dummyFetch("/success/data").then(function onFulfilled(response) {
     console.log(response); // => { body: "Response body of /success/data" }
 }, function onRejected(error) {
-    console.log(error); // この文は実行されません
+    // この文は実行されません
 });
 // /failure/data のリソースは存在しないのでonRejectedが呼ばれる
 dummyFetch("/failure/data").then(function onFulfilled(response) {
-    console.log(response); // この文は実行されません
+    // この文は実行されません
 }, function onRejected(error) {
     console.log(error); // Error: "NOT FOUND"
 });
@@ -541,7 +541,7 @@ function throwPromise() {
         // Promiseコンストラクタの中で例外は自動的にキャッチされrejectを呼ぶ
         throw new Error("例外が発生");
         // 例外が発生するとそれ以降の処理は実行されない
-        console.log("この文は実行されません");
+        // この文は実行されません
     });
 }
 

--- a/source/basic/error-try-catch/README.md
+++ b/source/basic/error-try-catch/README.md
@@ -20,7 +20,7 @@ try {
     console.log("この文は実行されます");
     // 未定義の関数を呼び出してReferenceError例外が発生する
     undefinedFunction();
-    console.log("この文は実行されません");
+    // この文は実行されません
 } catch (error) {
     // 例外が発生したあとはこのブロックが実行される
     console.log("この文は実行されます");
@@ -51,7 +51,7 @@ try {
     console.log("この文は実行されます");
 }
 // 上記のtry-finnalyで例外がキャッチされていないため
-console.log("この文は実行されません");
+// この文は実行されません
 ```
 
 ## throw文 {#throw}

--- a/test/markdown-doc-test.js
+++ b/test/markdown-doc-test.js
@@ -115,7 +115,8 @@ ${codeBlock.value}
                         // console.logと// => の書式をチェック
                         // ミスマッチが多いので無効化
                         // shouldConsoleWithComment(codeBlock.value, filePath);
-                        const poweredCode = toDoc.convertCode(codeBlock.value, filePath);
+                        const convertedUnreachableCode = codeBlock.value.replace(/^(\W*)\/\/ この文は実行されません$/gm, `$1throw new Error("この文は実行されません");`);
+                        const poweredCode = toDoc.convertCode(convertedUnreachableCode, filePath);
                         const unhandledRejectionHandler = (reason) => {
                             done(reason);
                         };


### PR DESCRIPTION
Fixes #584.

普通は実行されないが、提案通り修正を入れてみました。

この方法で対応すると、新規ラインでなければ、認識されないです。

```javascript
if (true) {
  console.log('foo');
} else {
  // この文は実行されません
}
```

✅ コード変換適用されます。

---

```javascript
if (true) {
  console.log('foo');
} else {
  // この文は実行されません
  console.error('foo');
}
```

✅ コード変換適用されます。

---

```javascript
if (true) {
  console.log('foo');
} else {
  console.error('foo'); // この文は実行されません
}
```

❌ コード変換適用されません。