### PR TITLE
MarkdownをHTMLに変換するページのリンク修正

### DIFF
--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -165,5 +165,5 @@ $ node main.js -S sample.md
 これでMarkdown変換の設定をコマンドライン引数でオプションとして与えられるようになりました。
 
 [marked]: https://github.com/chjj/marked
-[変換オプション]: https://github.com/chjj/marked#options-1
+[変換オプション]: https://marked.js.org/#/USING_ADVANCED.md#options
 [GitHub Flavored Markdown]: https://github.github.com/gfm/


### PR DESCRIPTION
README には Option に関する記述が無かったのでドキュメントの対応する場所にリンク先を修正しました。