### PR TITLE
fix(loop): while文のループログを追加

### DIFF
--- a/source/basic/loop/README.md
+++ b/source/basic/loop/README.md
@@ -125,7 +125,7 @@ let total = 0; // totalの初期値は0
 // iが10未満（条件式を満たす）ならfor文の処理を実行
 // iに1を足し、再び条件式の判定へ
 for (let i = 0; i < 10; i++) {
-    total += i + 1; // 1...10
+    total += i + 1; // 1から10の値をtotalに加算している
 }
 console.log(total); // => 55
 ```

--- a/source/basic/loop/src/while/while-add-example.js
+++ b/source/basic/loop/src/while/while-add-example.js
@@ -1,5 +1,7 @@
 let x = 0;
+console.log(`ループ開始前のxの値: ${x}`);
 while (x < 10) {
     console.log(x);
     x += 1;
 }
+console.log(`ループ終了後のxの値: ${x}`);

--- a/source/basic/loop/test/while/while-add-example-test.js
+++ b/source/basic/loop/test/while/while-add-example-test.js
@@ -15,6 +15,7 @@ describe("whileの加算", function() {
             console
         });
         assert.deepEqual(actualLogs, [
+            `ループ開始前のxの値: ${0}`,
             0,
             1,
             2,
@@ -24,7 +25,8 @@ describe("whileの加算", function() {
             6,
             7,
             8,
-            9
+            9,
+            `ループ終了後のxの値: ${10}`
         ]);
     });
 });


### PR DESCRIPTION
REPLの仕組み上、最後に評価した値が表示され(xが`10`)とでてしまうのが誤解を生むため修正。

ループ前後で`x`の値を明確に出すようにした

fix #763 