### PR TITLE
fix: use-case/todoapp/entrypoint の誤字修正

### DIFF
--- a/source/use-case/todoapp/entrypoint/README.md
+++ b/source/use-case/todoapp/entrypoint/README.md
@@ -51,7 +51,7 @@ JavaScriptモジュールを別々の`script`タグで読み込むと、モジ�
 同じように`index.js`を`todoapp`ディレクトリに作成し、次のような内容にします。
 `index.js`にはスクリプトが正しく読み込まれたことを確認できるように、コンソールにログを出力する処理だけを書いておきます。
 
-[import, title:"src/index.js"](first-entry/index.js)
+[import, title:"index.js"](first-entry/index.js)
 
 ここでの`todoapp`ディレクトリのファイル配置は次のようになっていれば問題ありません。
 


### PR DESCRIPTION
いつもお世話になっております。

[todoapp](https://jsprimer.net/use-case/todoapp/entrypoint/)のプロジェクトディレクトリ構成について、`index.js`は`todoapp`ディレクトリ直下に存在するため`src/index.js`というタイトルは間違いだと思われます。 