### PR TITLE
fix(todoapp): Rename EventLister -> EventListener (in EventEmitter)

### DIFF
--- a/source/use-case/todoapp/event-model/README.md
+++ b/source/use-case/todoapp/event-model/README.md
@@ -121,7 +121,7 @@ Node.jsでは、`events`と呼ばれるモジュールで同様のイベント�
 
 `EventEmitter`はイベントの仕組みで書いたディスパッチ側とリッスン側の機能を持ったクラスとなります。
 
-- ディスパッチ側: `addEventLister`メソッドは、指定した`イベント名`に任意のコールバック関数を登録できる
+- ディスパッチ側: `addEventListener`メソッドは、指定した`イベント名`に任意のコールバック関数を登録できる
 - リッスン側: `emit`メソッドは、指定された`イベント名`に登録済みのすべてのコールバック関数を呼び出す
 
 これによって、`emit`メソッドを呼び出すと指定したイベントに関係する登録済みのコールバック関数を呼び出せます。
@@ -132,10 +132,10 @@ Node.jsでは、`events`と呼ばれるモジュールで同様のイベント�
 [import, title:"src/EventEmitter.js"](./event-emitter/src/EventEmitter.js)
 
 この`EventEmitter`は次のようにイベントのリッスンとイベントのディスパッチの機能が利用できます。
-リッスン側は`addEventLister`メソッドでイベントの種類（`type`）に対するイベントリスナー（`listener`）を登録します。
+リッスン側は`addEventListener`メソッドでイベントの種類（`type`）に対するイベントリスナー（`listener`）を登録します。
 ディスパッチ側は`emit`メソッドでイベントをディスパッチし、イベントリスナーを呼び出します。
 
-次のコードでは、`addEventLister`メソッドで`test-event`イベントに対して2つのイベントリスナーを登録しています。
+次のコードでは、`addEventListener`メソッドで`test-event`イベントに対して2つのイベントリスナーを登録しています。
 そのため、`emit`メソッドで`test-event`イベントをディスパッチすると、登録済みのイベントリスナーが呼び出されています。
 
 [import, title:"EventEmitterの実行サンプル"](./event-emitter/src/EventEmitter.example.js)

--- a/source/use-case/todoapp/event-model/event-emitter/src/EventEmitter.example.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/EventEmitter.example.js
@@ -1,8 +1,8 @@
 import { EventEmitter } from "./EventEmitter.js";
 const event = new EventEmitter();
 // イベントリスナー（コールバック関数）を登録
-event.addEventLister("test-event", () => console.log("One!"));
-event.addEventLister("test-event", () => console.log("Two!"));
+event.addEventListener("test-event", () => console.log("One!"));
+event.addEventListener("test-event", () => console.log("Two!"));
 // イベントをディスパッチする
 event.emit("test-event");
 // コールバック関数がそれぞれ呼びだされ、コンソールには次のように出力される

--- a/source/use-case/todoapp/event-model/event-emitter/src/EventEmitter.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/final/create-view/src/EventEmitter.js
+++ b/source/use-case/todoapp/final/create-view/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/final/create-view/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/create-view/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/final/final/src/EventEmitter.js
+++ b/source/use-case/todoapp/final/final/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/final/final/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/final/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**
@@ -38,7 +38,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     offChange(listener) {
-        this.removeEventLister("change", listener);
+        this.removeEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/final/final/test/EventEmitter-test.js
+++ b/source/use-case/todoapp/final/final/test/EventEmitter-test.js
@@ -2,11 +2,11 @@ const assert = require("assert");
 import { EventEmitter } from "../src/EventEmitter.js";
 
 describe("EventEmitter", function() {
-    describe("#addEventLister", function() {
+    describe("#addEventListener", function() {
         it("should set event listener to the key", function(done) {
             const emitter = new EventEmitter();
             const key = "event-key";
-            emitter.addEventLister(key, function() {
+            emitter.addEventListener(key, function() {
                 done();
             });
             emitter.emit(key);
@@ -17,24 +17,24 @@ describe("EventEmitter", function() {
             const emitter = new EventEmitter();
             const key = "event-key";
             let isListenerCalled = false;
-            emitter.addEventLister(key, function() {
+            emitter.addEventListener(key, function() {
                 isListenerCalled = true;
             });
             emitter.emit(key);
             assert.ok(isListenerCalled, "listener should be called");
         });
     });
-    describe("#removeEventLister", function() {
+    describe("#removeEventListener", function() {
         it("should unset event listener ", function(done) {
             const emitter = new EventEmitter();
             const key = "event-key";
             const listener = function() {
                 done(new Error("should not called"));
             };
-            emitter.addEventLister(key, listener);
-            emitter.removeEventLister(key, listener);
+            emitter.addEventListener(key, listener);
+            emitter.removeEventListener(key, listener);
             emitter.emit(key);
-            emitter.addEventLister(key, done);
+            emitter.addEventListener(key, done);
             emitter.emit(key);
         });
     });

--- a/source/use-case/todoapp/final/more/src/App.js
+++ b/source/use-case/todoapp/final/more/src/App.js
@@ -87,6 +87,6 @@ export class App {
      */
     unmount() {
         this.todoListModel.offChange(this.handleChange);
-        this.formElement.removeEventLister("submit", this.handleSubmit);
+        this.formElement.removeEventListener("submit", this.handleSubmit);
     }
 }

--- a/source/use-case/todoapp/final/more/src/EventEmitter.js
+++ b/source/use-case/todoapp/final/more/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/final/more/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/more/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/final/more/test/EventEmitter-test.js
+++ b/source/use-case/todoapp/final/more/test/EventEmitter-test.js
@@ -2,11 +2,11 @@ const assert = require("assert");
 import { EventEmitter } from "../src/EventEmitter.js";
 
 describe("EventEmitter", function() {
-    describe("#addEventLister", function() {
+    describe("#addEventListener", function() {
         it("should set event listener to the key", function(done) {
             const emitter = new EventEmitter();
             const key = "event-key";
-            emitter.addEventLister(key, function() {
+            emitter.addEventListener(key, function() {
                 done();
             });
             emitter.emit(key);
@@ -17,24 +17,24 @@ describe("EventEmitter", function() {
             const emitter = new EventEmitter();
             const key = "event-key";
             let isListenerCalled = false;
-            emitter.addEventLister(key, function() {
+            emitter.addEventListener(key, function() {
                 isListenerCalled = true;
             });
             emitter.emit(key);
             assert.ok(isListenerCalled, "listener should be called");
         });
     });
-    describe("#removeEventLister", function() {
+    describe("#removeEventListener", function() {
         it("should unset event listener ", function(done) {
             const emitter = new EventEmitter();
             const key = "event-key";
             const listener = function() {
                 done(new Error("should not called"));
             };
-            emitter.addEventLister(key, listener);
-            emitter.removeEventLister(key, listener);
+            emitter.addEventListener(key, listener);
+            emitter.removeEventListener(key, listener);
             emitter.emit(key);
-            emitter.addEventLister(key, done);
+            emitter.addEventListener(key, done);
             emitter.emit(key);
         });
     });

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/EventEmitter.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/update-delete/delete-feature/src/EventEmitter.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**

--- a/source/use-case/todoapp/update-delete/update-feature/src/EventEmitter.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/EventEmitter.js
@@ -9,7 +9,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    addEventLister(type, listener) {
+    addEventListener(type, listener) {
         // 指定したイベントに対応するSetを作成しリスナー関数を登録する
         if (!this._listeners.has(type)) {
             this._listeners.set(type, new Set());
@@ -38,7 +38,7 @@ export class EventEmitter {
      * @param {string} type イベント名
      * @param {Function} listener イベントリスナー
      */
-    removeEventLister(type, listener) {
+    removeEventListener(type, listener) {
         // 指定したイベントに対応するSetを取り出し、該当するリスナー関数を削除する
         const listenerSet = this._listeners.get(type);
         if (!listenerSet) {

--- a/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.js
@@ -30,7 +30,7 @@ export class TodoListModel extends EventEmitter {
      * @param {Function} listener
      */
     onChange(listener) {
-        this.addEventLister("change", listener);
+        this.addEventListener("change", listener);
     }
 
     /**


### PR DESCRIPTION
# Overview

Todoアプリの `EventEmitter` クラス内のメソッド `addEventLister()` および `removeEventLister()` を改名しました。

命名の衝突防止等の理由がございましたら、無視していただいて構いません。

# Changes

- TodoアプリのドキュメントおよびJSでのメソッド名変更( `src/EventEmitter.js` 内)
    - メソッド `EventEmitter#addEventLister()` -> `addEventListener()`
    - メソッド `EventEmitter#removeEventLister()` -> `removeEventListener()`

