### PR TITLE
TodoItemModelとTodoListModelの例でimportしているパスを修正

### DIFF
--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoItemModel.example.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoItemModel.example.js
@@ -1,4 +1,4 @@
-import { TodoItemModel } from "./TodoItemModel";
+import { TodoItemModel } from "./TodoItemModel.js";
 const item = new TodoItemModel({
     title: "未完了のTodoアイテム",
     completed: false

--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.example.js
@@ -1,5 +1,5 @@
-import { TodoItemModel } from "./TodoItemModel";
-import { TodoListModel } from "./TodoListModel";
+import { TodoItemModel } from "./TodoItemModel.js";
+import { TodoListModel } from "./TodoListModel.js";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0


### PR DESCRIPTION
TodoItemModelとTodoListModelの例として載っているTodoItemModel.example.jsとTodoListModel.example.jsのimportのパスに.jsがついていなかったので追加しました．