### PR TITLE
refactor(todo): `TodoListModel#totalCount` を `TodoListModel#getTotalCount`メソッドに変更

### DIFF
--- a/source/use-case/todoapp/event-model/README.md
+++ b/source/use-case/todoapp/event-model/README.md
@@ -240,7 +240,7 @@ export class App {
 ```
 
 この作成した`todoListElement`要素を前回作成した、`html-util.js`の`render`関数を使い`containerElement`の中身を上書きしてます。
-また、アイテム数は`TodoListModel#totalCount`で取得できるため、アイテム数だけを管理していた`todoItemCount`という変数は削除できます。
+また、アイテム数は`TodoListModel#getTotalCount`メソッドで取得できるため、アイテム数だけを管理していた`todoItemCount`という変数は削除できます。
 
 <!-- doctest:disable -->
 ```js
@@ -255,7 +255,7 @@ export class App {
             // containerElementの中身をtodoListElementで上書きする
             render(todoListElement, containerElement);
             // アイテム数の表示を更新
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         // ...省略...
     }

--- a/source/use-case/todoapp/event-model/README.md
+++ b/source/use-case/todoapp/event-model/README.md
@@ -240,7 +240,7 @@ export class App {
 ```
 
 この作成した`todoListElement`要素を前回作成した、`html-util.js`の`render`関数を使い`containerElement`の中身を上書きしてます。
-また、アイテム数は`TodoListModel#getTotalCount`メソッドで取得できるため、アイテム数だけを管理していた`todoItemCount`という変数は削除できます。
+また、アイテム数は`TodoListModel#getTotalCount`メソッドで取得できるため、アイテム数を管理していた`todoItemCount`という変数は削除できます。
 
 <!-- doctest:disable -->
 ```js

--- a/source/use-case/todoapp/event-model/event-emitter/src/App.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/App.js
@@ -25,7 +25,7 @@ export class App {
             // containerElementの中身をtodoListElementで上書きする
             render(todoListElement, containerElement);
             // アイテム数の表示を更新
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         // 3. フォームを送信したら、新しいTodoItemModelを追加する
         formElement.addEventListener("submit", (event) => {

--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel.js";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -15,4 +15,4 @@ todoListModel.addTodo(new TodoItemModel({
     completed: false
 }));
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1

--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
@@ -13,7 +13,7 @@ export class TodoListModel extends EventEmitter {
      * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/model/TodoListModel.js
@@ -10,7 +10,7 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
     get totalCount() {

--- a/source/use-case/todoapp/final/create-view/src/App.js
+++ b/source/use-case/todoapp/final/create-view/src/App.js
@@ -28,7 +28,7 @@ export class App {
                 }
             });
             render(todoListElement, containerElement);
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         formElement.addEventListener("submit", (event) => {
             event.preventDefault();

--- a/source/use-case/todoapp/final/create-view/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/final/create-view/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -16,9 +16,9 @@ const todoItemModel = new TodoItemModel({
 });
 todoListModel.addTodo(todoItemModel);
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1
 // アイテムを削除する
 todoListModel.deleteTodo({
     id: todoItemModel.id
 });
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0

--- a/source/use-case/todoapp/final/create-view/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/create-view/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/final/final/src/App.js
+++ b/source/use-case/todoapp/final/final/src/App.js
@@ -50,7 +50,7 @@ export class App {
                 }
             });
             render(todoListElement, todoListContainerElement);
-            todoCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
 
         formElement.addEventListener("submit", (event) => {

--- a/source/use-case/todoapp/final/final/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/final/final/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -16,9 +16,9 @@ const todoItemModel = new TodoItemModel({
 });
 todoListModel.addTodo(todoItemModel);
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1
 // アイテムを削除する
 todoListModel.deleteTodo({
     id: todoItemModel.id
 });
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0

--- a/source/use-case/todoapp/final/final/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/final/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/final/more/src/App.js
+++ b/source/use-case/todoapp/final/more/src/App.js
@@ -71,7 +71,7 @@ export class App {
             }
         });
         render(todoListElement, todoListContainerElement);
-        todoCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+        todoCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
     }
 
     /**

--- a/source/use-case/todoapp/final/more/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/more/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/App.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/App.js
@@ -25,7 +25,7 @@ export class App {
             });
             //! [checkbox]
             render(todoListElement, containerElement);
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         formElement.addEventListener("submit", (event) => {
             event.preventDefault();

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -15,4 +15,4 @@ todoListModel.addTodo(new TodoItemModel({
     completed: false
 }));
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/update-delete/delete-feature/src/App.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/App.js
@@ -45,7 +45,7 @@ export class App {
             });
             //! [checkbox]
             render(todoListElement, containerElement);
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         formElement.addEventListener("submit", (event) => {
             event.preventDefault();

--- a/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -16,9 +16,9 @@ const todoItemModel = new TodoItemModel({
 });
 todoListModel.addTodo(todoItemModel);
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1
 // アイテムを削除する
 todoListModel.deleteTodo({
     id: todoItemModel.id
 });
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0

--- a/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 

--- a/source/use-case/todoapp/update-delete/update-feature/src/App.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/App.js
@@ -33,7 +33,7 @@ export class App {
             });
             //! [checkbox]
             render(todoListElement, containerElement);
-            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.totalCount}`;
+            todoItemCountElement.textContent = `Todoアイテム数: ${this.todoListModel.getTotalCount()}`;
         });
         formElement.addEventListener("submit", (event) => {
             event.preventDefault();

--- a/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.example.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.example.js
@@ -3,7 +3,7 @@ import { TodoListModel } from "./TodoListModel";
 // 新しいTodoリストを作成する
 const todoListModel = new TodoListModel();
 // 現在のTodoアイテム数は0
-console.log(todoListModel.totalCount); // => 0
+console.log(todoListModel.getTotalCount()); // => 0
 // Todoリストが変更されたら呼ばれるイベントリスナーを登録する
 todoListModel.onChange(() => {
     console.log("TodoListの状態が変わりました");
@@ -16,7 +16,7 @@ const todoItemModel = new TodoItemModel({
 });
 todoListModel.addTodo(todoItemModel);
 // Todoリストにアイテムが増える
-console.log(todoListModel.totalCount); // => 1
+console.log(todoListModel.getTotalCount()); // => 1
 // 完了状態を更新する
 todoListModel.updateTodo({
     id: todoItemModel.id,

--- a/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/model/TodoListModel.js
@@ -10,10 +10,10 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
-     * TodoItemの合計数を返す
+     * TodoItemの合計個数を返す
      * @returns {number}
      */
-    get totalCount() {
+    getTotalCount() {
         return this.items.length;
     }
 


### PR DESCRIPTION
## 目的

TodoListModelで`get totalCount`と`getTodoItems()`という命名規則の混在があった
(getなのに定義方法がバラバラ)
これを`getXXX`メソッドに統一し、getterを使わなくする。
特にgetterである必要性はないのと、だれが見ても何を求めているのかがわかりやすいことを優先している
(getXXXみたいな命名はダサい所はあるけど、無理してgetterに統一する意味もないのと、getterよりはメソッドの方が見た目でわかりやすい気がする。結局、この辺は好みの問題になりそう。)

fix https://github.com/asciidwango/js-primer/pull/782


📝 その他の修正案

- https://github.com/asciidwango/js-primer/pull/782#discussion_r283121323 を参照




/cc @otokunaga2