### PR TITLE
feat(meeting): 2019-05-30のミーティングログ

### DIFF
--- a/meetings/2019-05-30/README.md
+++ b/meetings/2019-05-30/README.md
@@ -1,0 +1,49 @@
+# 2019-05-30 Meeting Notes
+
+- [@azu](https://github.com/azu)
+- [@kahei](https://github.com/kahei)
+- [@lacolaco](https://github.com/lacolaco)
+
+----
+
+## ミーティングアジェンダ
+
+- [2019-05-30 ミーティングアジェンダ · Issue #803 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/803)
+
+---
+
+## CLA 
+
+- azu: CLAを追加した
+- https://github.com/asciidwango/js-primer/blob/master/CLA.md
+
+
+### 結論
+
+- 文章やコードの追加についてはCLAを求める形にする
+
+----
+
+## レビューアからのフィードバック読み合わせ
+
+- レビューを読みながらいろいろな修正方針をまとめた
+- それぞれ修正する内容はIssueを作成した
+- [all: typeof 演算子の結果とか被る変数名は避ける · Issue #804 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/804)
+- [モジュールの章を移動する · Issue #644 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/644)
+- [アプリケーション開発の準備 に ローカルサーバの立ち上げ方法を追加する · Issue #805 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/805)
+- [変数と宣言: const, let, varの順番で解説を書きなおす · Issue #806 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/806)
+- [strict modeについて補足/リンクを入れる · Issue #807 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/807)
+- [プロトタイプオブジェクト: 章の最初に目的を入れる · Issue #809 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/809)
+- [GCについての図がほしい · Issue #810 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/810)
+- [非同期処理: タイトルの変更 · Issue #811 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/811)
+- [Ajax: Fetch APIベースに書き換える · Issue #812 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/812)
+- [暗黙的な型変換: 章の最初に目的を入れる · Issue #808 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/808)
+- [All: 章の末尾をチェックリストで統一する · Issue #813 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/813)
+- [All: エラーの表記を統一する · Issue #814 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/814)
+
+
+----
+
+## 次回
+
+2019年7月1日（月）


### PR DESCRIPTION
今回はほとんどがレビューフィードバックの読み合わせだったのでログらしいログはありません。
フィードバックを元に作成したIssue一覧を書いています。

* [all: typeof 演算子の結果とか被る変数名は避ける · Issue #804 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/804)
* [モジュールの章を移動する · Issue #644 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/644)
* [アプリケーション開発の準備 に ローカルサーバの立ち上げ方法を追加する · Issue #805 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/805)
* [変数と宣言: const, let, varの順番で解説を書きなおす · Issue #806 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/806)
* [strict modeについて補足/リンクを入れる · Issue #807 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/807)
* [プロトタイプオブジェクト: 章の最初に目的を入れる · Issue #809 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/809)
* [GCについての図がほしい · Issue #810 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/810)
* [非同期処理: タイトルの変更 · Issue #811 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/811)
* [Ajax: Fetch APIベースに書き換える · Issue #812 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/812)
* [暗黙的な型変換: 章の最初に目的を入れる · Issue #808 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/808)
* [All: 章の末尾をチェックリストで統一する · Issue #813 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/813)
* [All: エラーの表記を統一する · Issue #814 · asciidwango/js-primer](https://github.com/asciidwango/js-primer/issues/814)

close #803 