### PR TITLE
chore: consoleのコードと結果を一致させる

### DIFF
--- a/source/basic/data-type/src/octal-legacy-literal-invalid.js
+++ b/source/basic/data-type/src/octal-legacy-literal-invalid.js
@@ -1,4 +1,4 @@
 // 非推奨な8進数の書き方
 // strict modeは例外が発生
 console.log(0644);  // => 420
-console.log(0755);  // => 511
+console.log(0777);  // => 511


### PR DESCRIPTION
consoleのコードと結果が一致していないようだったので修正しました。
(直前の例で、`0o777` を使っていたので、そちらに合わせる形でコードの方を直しました。)