### PR TITLE
chore: タイトルをJavaScript Primerに決定

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [WIP] JavaScriptの入門書 [![Build Status](https://travis-ci.org/asciidwango/js-primer.svg?branch=master)](https://travis-ci.org/asciidwango/js-primer)
+# JavaScript Primer [![Build Status](https://travis-ci.org/asciidwango/js-primer.svg?branch=master)](https://travis-ci.org/asciidwango/js-primer)
 
-この書籍はES2015以降をベースとしたJavaScript入門書となる予定です。
+この書籍はES2015以降をベースとしたJavaScript入門書です。
 
 プログラミングをやったことがあるが、今のJavaScriptがよくわからないという人が、
 今のJavaScriptアプリケーションを読み書きできるようになる目的の書籍です。

--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
   "gitbook": ">=3.0.0",
-  "title": "JavaScriptの入門書 #jsprimer",
-  "description": "JavaScriptの基本的な文法からアプリケーションの作成などの実例を学ぶJavaScriptの入門書です",
+  "title": "JavaScript Primer #jsprimer",
+  "description": "JavaScriptの基本的な書き方からアプリケーションの作成などのユースケースを学ぶための入門書です",
   "root": "./source/",
   "structure": {
     "readme": "index.md",

--- a/source/index.md
+++ b/source/index.md
@@ -1,7 +1,7 @@
 ---
 author: azu
-title: "JavaScriptの入門書 #jsprimer"
-description: "JavaScriptの基本的なプログラムの実行方法からアプリケーションの作成などの実例を学ぶための入門書です"
+title: "JavaScript Primer #jsprimer"
+description: "JavaScriptの基本的な書き方からアプリケーションの作成などのユースケースを学ぶための入門書です"
 ---
 
 {% include "./landing/index.html" %}

--- a/source/landing/index.html
+++ b/source/landing/index.html
@@ -4,16 +4,16 @@
 <div class="page-container">
     <div class="row main" id="js-main">
         <div class="col-sm-8">
-            <h2 class="mg-lg Landing-title">
-                [WIP] JavaScriptの入門書
-            </h2>
+            <h2 class="mg-lg Landing-title">JavaScript Primer</h2>
             <h3 class="mg-sm">
                 <span class="fa fa-book"></span>ECMAScript 2018時代のJavaScript入門書
             </h3>
             <p class="mg-lg">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-size="large">Tweet</a>
-                <a class="github-button" href="https://github.com/asciidwango/js-primer/subscription" data-size="large" data-show-count="true" aria-label="Watch asciidwango/js-primer on GitHub">Watch</a>
-                <a class="github-button" href="https://github.com/asciidwango/js-primer" data-size="large" data-show-count="true" aria-label="Star asciidwango/js-primer on GitHub">Star</a>
+                <a class="github-button" href="https://github.com/asciidwango/js-primer/subscription" data-size="large"
+                   data-show-count="true" aria-label="Watch asciidwango/js-primer on GitHub">Watch</a>
+                <a class="github-button" href="https://github.com/asciidwango/js-primer" data-size="large"
+                   data-show-count="true" aria-label="Star asciidwango/js-primer on GitHub">Star</a>
             </p>
             <p class="mg-lg">
                 これからJavaScriptに入門したい人が、ECMAScript 2015以降をベースにして一からJavaScriptを学べる本です。<br/>
@@ -21,7 +21,7 @@
                 今のJavaScriptアプリケーションを読み書きできるようになるように書かれています。
             </p>
             <p class="mg-lg">
-                初めてのプログラミング言語としてJavaScriptを学ぶ人は、まずは「<a href="https://jsprimer.net/intro/">はじめに</a>」から読んでみてください。<br />
+                初めてのプログラミング言語としてJavaScriptを学ぶ人は、まずは「<a href="https://jsprimer.net/intro/">はじめに</a>」から読んでみてください。<br/>
             </p>
             <form action="https://github.us13.list-manage.com/subscribe/post?u=fc41e11a2b9dc6f05350e0de0&amp;id=7ab1594ae8"
                   method="post" id="js_mail_form" novalidate class="mail-form" target="_blank">
@@ -30,7 +30,7 @@
                 </h3>
                 <p class="mg-lg">
                     この本は現在実装中であるため、予告なしに変更される可能性があります。<br/>
-                    この本の更新情報を受け取りたい方はメールアドレスを登録することで通知を受け取れます。<br />
+                    この本の更新情報を受け取りたい方はメールアドレスを登録することで通知を受け取れます。<br/>
                     この本がリリースされるタイミングなどの情報を受け取れます。
                 </p>
                 <div class="form-group">
@@ -51,5 +51,13 @@
 </div>
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<script async defer>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<script async defer>!function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? "http" : "https";
+    if (!d.getElementById(id)) {
+        js = d.createElement(s);
+        js.id = id;
+        js.src = p + "://platform.twitter.com/widgets.js";
+        fjs.parentNode.insertBefore(js, fjs);
+    }
+}(document, "script", "twitter-wjs");</script>
 <!-- Main End -->


### PR DESCRIPTION
#860 タイトルは"JavaScript Primer"に決定した。略称は js-primer を維持。
サブタイトルはまだ検討中。

## 変更点

- タイトルを"JavaScript Primer"に変更
- WIPを外した