### PR TITLE
fix: 未定義エラーになっていた関数を定義する (EventListenerの解除)

### DIFF
--- a/source/use-case/todoapp/final/more/src/model/TodoListModel.js
+++ b/source/use-case/todoapp/final/more/src/model/TodoListModel.js
@@ -34,6 +34,14 @@ export class TodoListModel extends EventEmitter {
     }
 
     /**
+     * TodoListの状態が更新されたときに呼び出されるリスナー関数を解除する
+     * @param {Function} listener
+     */
+    offChange(listener) {
+        this.removeEventListener("change", listener);
+    }
+
+    /**
      * 状態が変更されたときに呼ぶ。登録済みのリスナー関数を呼び出す
      */
     emitChange() {


### PR DESCRIPTION
以下のメソッドで `TodoListModel#offChange` が呼ばれているのですが、未定義のようだったので追加しました。

https://github.com/asciidwango/js-primer/blob/f0bb4c986c788473790f52fd6e1b704d9434259c/source/use-case/todoapp/final/more/src/App.js#L85-L91