### PR TITLE
fix: Node.js と npm のバージョンを LTS に合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Twitterのハッシュタグは [#jsprimer](https://twitter.com/intent/tweet?has
 
     npm install
 
-Node.js 8.2.0以上が必要です。
+Node.js 12.13.0以上が必要です。
 `npx`コマンドが利用できることを確認してください。
 
 ## Usage

--- a/book.json
+++ b/book.json
@@ -20,8 +20,8 @@
   ],
   "variables": {
     "esversion": "2019",
-    "nodeversion": "8.12.0",
-    "npmversion": "6.4.1",
+    "nodeversion": "12.13.0",
+    "npmversion": "6.12.0",
     "triplebackticks": "```",
     "console": "<a class=\"gitbook-plugin-js-console\" aria-hidden=\"true\"></a>"
   },

--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -13,7 +13,7 @@ description: "コマンドライン引数を受け取り、アプリケーショ
 コマンドライン引数を扱う前に、まずは`process`オブジェクトについて触れておきます。
 `process`オブジェクトはNode.js実行環境のグローバル変数のひとつです。
 `process`オブジェクトが提供するのは、現在のNode.jsの実行プロセスについて、情報の取得と操作をするAPIです。
-詳細は[公式ドキュメント](https://nodejs.org/dist/latest-v8.x/docs/api/process.html#process_process)を参照してください。
+詳細は[公式ドキュメント](https://nodejs.org/dist/latest-v12.x/docs/api/process.html#process_process)を参照してください。
 
 コマンドライン引数へのアクセスを提供するのは、`process`オブジェクトの`argv`プロパティで、文字列の配列になっています。
 次のように`main.js`を変更し、`process.argv`をコンソールに出力しましょう。
@@ -176,7 +176,7 @@ $ node main.js ./sample.md
 [npmのGitHubリポジトリ]: https://github.com/npm/npm
 [CommonJSモジュール]: https://nodejs.org/docs/latest/api/modules.html
 [Node.js]: https://nodejs.org/ja/
-[require関数]: https://nodejs.org/dist/latest-v8.x/docs/api/modules.html#modules_loading_from_node_modules_folders
+[require関数]: https://nodejs.org/dist/latest-v12.x/docs/api/modules.html#modules_loading_from_node_modules_folders
 [アプリケーション開発の準備]: ../../setup-local-env/README.md
 [ECMAScriptモジュール]: ../../../basic/module/README.md
 [^1]: --saveオプションをつけてインストールしたのと同じ意味。npm 5.0.0からは--saveがデフォルトオプションとなりました。

--- a/source/use-case/nodecli/helloworld/README.md
+++ b/source/use-case/nodecli/helloworld/README.md
@@ -85,6 +85,6 @@ ECMAScriptで定義されているグローバルオブジェクトはブラウ�
 
 [document]: https://developer.mozilla.org/ja/docs/Web/API/Document
 [XMLHttpRequest]: https://developer.mozilla.org/ja/docs/Web/API/XMLHttpRequest
-[global]: https://nodejs.org/docs/latest-v8.x/api/globals.html
-[process]: https://nodejs.org/docs/latest-v8.x/api/process.html#process_process
-[Buffer]: https://nodejs.org/docs/latest-v8.x/api/buffer.html
+[global]: https://nodejs.org/docs/latest-v12.x/api/globals.html
+[process]: https://nodejs.org/docs/latest-v12.x/api/process.html#process_process
+[Buffer]: https://nodejs.org/docs/latest-v12.x/api/buffer.html


### PR DESCRIPTION
#976 の対応です。

ref
https://nodejs.org/en/blog/release/v12.13.0/