### PR TITLE
chore(title): "JavaScript Primer - 迷わないための入門書"に変更

### DIFF
--- a/source/landing/index.html
+++ b/source/landing/index.html
@@ -6,7 +6,7 @@
         <div class="col-sm-8">
             <h2 class="mg-lg Landing-title">JavaScript Primer</h2>
             <h3 class="mg-sm">
-                <span class="fa fa-book"></span>ECMAScript 2019時代のJavaScript入門書
+                <span class="fa fa-book"></span>迷わないための入門書
             </h3>
             <p class="mg-lg">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-size="large">Tweet</a>


### PR DESCRIPTION
サブタイトルを統一

![image](https://user-images.githubusercontent.com/19714/74583430-673a7200-500a-11ea-9853-ac27ee37cac4.png)

![image](https://user-images.githubusercontent.com/19714/74583521-2131de00-500b-11ea-83b9-6c0210463dcf.png)



fix #865 