### PR TITLE
fix(chap05): "コラム" を避ける

### DIFF
--- a/TeX/chap05.tex
+++ b/TeX/chap05.tex
@@ -405,7 +405,7 @@ fn();
 var null; // => SyntaxError
 \end{lstlisting}
 
-このコラムでは、説明のために\texttt{undefined}というローカル変数を宣言しましたが、\texttt{undefined}の再定義は非推奨です。
+ここでは、説明のために\texttt{undefined}というローカル変数を宣言しましたが、\texttt{undefined}の再定義は非推奨です。
 無用な混乱を生むだけなので避けるべきです。
 \end{tcolorbox}
 


### PR DESCRIPTION
ref #1087 のバックポート