### PR TITLE
fix(chap30/chap31): "「アプリケーション開発の準備」の章"に統一

### DIFF
--- a/TeX/chap30.tex
+++ b/TeX/chap30.tex
@@ -91,7 +91,7 @@ Policy}のセキュリティ制限により、多くの場面でアプリケー�
 
 コマンドラインで\texttt{ajaxapp}ディレクトリへ移動し、次のコマンドでローカルサーバーを起動します。
 次のコマンドでは、この書籍用に作成された\texttt{@js-primer/local-server}というローカルサーバーモジュールをダウンロードと同時に実行します。
-まだ\texttt{npx}コマンドの用意ができていなければ、先に「\hyperlink{setup-local-env}{アプリケーション開発の準備}」を参照してください。
+まだ\texttt{npx}コマンドの用意ができていなければ、先に「\hyperlink{setup-local-env}{アプリケーション開発の準備}」の章を参照してください。
 
 \begin{lstlisting}
 $ npx @js-primer/local-server

--- a/TeX/chap31.tex
+++ b/TeX/chap31.tex
@@ -183,7 +183,7 @@ $ node main.js one two=three four
 \subsubsection{\texorpdfstring{\texttt{commander}パッケージをインストールする}{commanderパッケージをインストールする}}\label{install-commander}}
 
 commanderは\href{https://www.npmjs.com/}{npm}の\texttt{npm install}コマンドを使ってインストールできます。
-まだnpmの実行環境を用意できていなければ、先に「\hyperlink{setup-local-env}{アプリケーション開発の準備}」を参照してください。
+まだnpmの実行環境を用意できていなければ、先に「\hyperlink{setup-local-env}{アプリケーション開発の準備}」の章を参照してください。
 
 npmでパッケージをインストールする前に、まずは\texttt{pacakge.json}というファイルを作成します。
 \texttt{package.json}とは、アプリケーションが依存するパッケージの種類やバージョンなどの情報を記録するJSON形式のファイルです。


### PR DESCRIPTION
chap32だと「アプリケーション開発の準備」の章になっているので他の章もあわせる。