### PR TITLE
chore: fix typo in statement-expression

### DIFF
--- a/source/basic/statement-expression/README.md
+++ b/source/basic/statement-expression/README.md
@@ -144,11 +144,11 @@ SyntaxError: redeclaration of const count
 » {
     const count = 1;
 }
-undfined // ここでブロック内で定義した変数`count`は参照できなくなる
+undefined // ここでブロック内で定義した変数`count`は参照できなくなる
 » {
     const count = 1;
 }
-undfined // ここでブロック内で定義した変数`count`は参照できなくなる
+undefined // ここでブロック内で定義した変数`count`は参照できなくなる
 ```
 
 これは、ブロックスコープという仕組みによるものですが、詳しい仕組みについては「[関数とスコープ][]」の章で解説します。


### PR DESCRIPTION
第一部 基本文法の「文と式」にtypoがあったので修正しました。
ご確認よろしくお願いいたします。