### PR TITLE
fix(use-case/nodecli): update marked@1.0.0

### DIFF
--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -14,7 +14,7 @@ JavaScriptでMarkdownをHTMLへ変換するために、今回は[marked][]とい
 markedのパッケージはnpmで配布されているので、commanderと同様に`npm install`コマンドでパッケージをインストールしましょう。
 
 ```shell-session
-$ npm install --save marked@0.8.0
+$ npm install --save marked@1.0.0
 ```
 
 インストールが完了したら、Node.jsのスクリプトから読み込みます。

--- a/source/use-case/nodecli/md-to-html/src/package-lock.json
+++ b/source/use-case/nodecli/md-to-html/src/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
     }
   }
 }

--- a/source/use-case/nodecli/md-to-html/src/package.json
+++ b/source/use-case/nodecli/md-to-html/src/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^5.0.0",
-    "marked": "^0.8.0"
+    "marked": "^1.0.0"
   }
 }

--- a/source/use-case/nodecli/refactor-and-unittest/src/package-lock.json
+++ b/source/use-case/nodecli/refactor-and-unittest/src/package-lock.json
@@ -506,9 +506,9 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/source/use-case/nodecli/refactor-and-unittest/src/package.json
+++ b/source/use-case/nodecli/refactor-and-unittest/src/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^5.0.0",
-    "marked": "^0.8.0"
+    "marked": "1.0.0"
   },
   "devDependencies": {
     "mocha": "^7.0.0"


### PR DESCRIPTION
#1155 の対応です。

下記ページの内容を`1.0.0`で動かしてみましたが、問題ありませんでした。
https://jsprimer.net/use-case/nodecli/md-to-html/