### PR TITLE
chore(string): stripSlashBaseURl -> stripSlashBaseURL

### DIFF
--- a/source/basic/string/README.md
+++ b/source/basic/string/README.md
@@ -1020,8 +1020,8 @@ getResource(baseURL, pathname);
 // ベースURLとパスを結合した文字列を返す
 function baseJoin(baseURL, pathname) {
     // 末尾に / がある場合は、/を削除してから結合する
-    const stripSlashBaseURl = baseURL.replace(/\/$/, "");
-    return stripSlashBaseURl + pathname;
+    const stripSlashBaseURL = baseURL.replace(/\/$/, "");
+    return stripSlashBaseURL + pathname;
 }
 // `baseURL`と`pathname`にあるリソースを取得する
 function getResource(baseURL, pathname) {


### PR DESCRIPTION
「文字列」の章の「文字列の組み立て」節における `stripSlashBaseURl` という変数名ですが、末尾の `l` が小文字になっており、タイポと思われるので修正します。