### PR TITLE
fix(loop): for...in文についてのES2020の変更点を反映

### DIFF
--- a/source/basic/loop/README.md
+++ b/source/basic/loop/README.md
@@ -317,7 +317,7 @@ const filteredArray = array.filter((currentValue, index, array) => {
 
 ## for...in文 {#for-in-statement}
 
-for...in文はオブジェクトのプロパティに対して、順不同で反復処理を行います。
+for...in文はオブジェクトのプロパティに対して、反復処理を行います。[^1]
 
 <!-- doctest:disable -->
 ```js
@@ -444,3 +444,4 @@ for文などの構文ではcontinue文やbreak文が利用できますが、配�
 [配列]: ../array/README.md
 [関数とスコープ]: .../function-scope/README.md
 [ブロックスコープ]: .../function-scope/README.md#block-scope
+[^1]: `for...in`文がプロパティを列挙する順番はES2019までは実装依存でしたが、ES2020で決められました。

--- a/source/basic/loop/README.md
+++ b/source/basic/loop/README.md
@@ -444,4 +444,4 @@ for文などの構文ではcontinue文やbreak文が利用できますが、配�
 [配列]: ../array/README.md
 [関数とスコープ]: .../function-scope/README.md
 [ブロックスコープ]: .../function-scope/README.md#block-scope
-[^1]: `for...in`文がプロパティを列挙する順番はES2019までは実装依存でしたが、ES2020で決められました。
+[^1]: `for...in`文がプロパティを列挙する順番はES2019までは実装依存でしたが、ES2020で列挙する順番が決められました。


### PR DESCRIPTION
`for...in`文がプロパティを列挙する順番はES2019までは実装依存だった。
これがES2020では仕様として列挙する順番が規程されたので、異なる列挙をするブラウザは基本的になくなる。(現時点ではすでにどのブラウザも同じ順番)
背景としては、`Reflect.ownKeys`(ES2015)が入った際に大体の実装が同じ列挙順に統一されたため、仕様が修正された。

詳細

- https://github.com/tc39/proposal-for-in-order
- https://github.com/tc39/proposal-for-in-order/blob/master/exploration/README.md
- https://github.com/tc39/ecma262/pull/1791 仕様の修正
- https://github.com/tc39/test262/pull/2432 テストの実装

fix #1180 
