### PR TITLE
chore: サマリの表記を修正

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -37,7 +37,7 @@
     - [第一部: おわりに](./basic/other-parts/README.md)
 - [第二部: 応用編（ユースケース）](./use-case/README.md)
     - [アプリケーション開発の準備](./use-case/setup-local-env/README.md)
-    - [Ajaxで通信](./use-case/ajaxapp/README.md)
+    - [Ajax通信](./use-case/ajaxapp/README.md)
       - [エントリーポイント](./use-case/ajaxapp/entrypoint/README.md)
       - [HTTP通信](./use-case/ajaxapp/http/README.md)
       - [データを表示する](./use-case/ajaxapp/display/README.md)

--- a/source/cheetsheet/README.md
+++ b/source/cheetsheet/README.md
@@ -304,7 +304,7 @@ JavaScriptにおける基本的なプロジェクトレイアウト、ファイ�
 [第一部: おわりに]: ../basic/other-parts/README.md
 [第二部: 応用編（ユースケース）]: ../use-case/README.md
 [アプリケーション開発の準備]: ../use-case/setup-local-env/README.md
-[Ajaxで通信]: ../use-case/ajaxapp/README.md
+[Ajax通信]: ../use-case/ajaxapp/README.md
 [エントリーポイント]: ../use-case/ajaxapp/entrypoint/README.md
 [HTTP通信]: ../use-case/ajaxapp/http/README.md
 [データを表示する]: ../use-case/ajaxapp/display/README.md

--- a/source/use-case/README.md
+++ b/source/use-case/README.md
@@ -13,7 +13,7 @@ description: "第二部では第一部の基本文法で学んだことを応用
 
 アプリケーション開発のためにNode.jsとnpmのインストールなどの準備方法を紹介します。
 
-### [Ajaxで通信](./ajaxapp/README.md) {#ajaxapp}
+### [Ajax通信](./ajaxapp/README.md) {#ajaxapp}
 
 ウェブブラウザ上でAjax通信をするユースケースとして、GitHubのユーザーIDからプロフィール情報を取得するアプリケーションを作成しながら、非同期処理について紹介します。
 


### PR DESCRIPTION
「Ajax通信」の表記をページ側のタイトルに合わせて統一しました。

https://www.kadokawa.co.jp/product/302003000984/
書籍版の目次は「第30章 ユースケース: Ajax通信」になってますね。