### PR TITLE
fix(usecase/ajaxapp): userIdを二重にencodeしない

### DIFF
--- a/source/use-case/ajaxapp/promise/src/index.js
+++ b/source/use-case/ajaxapp/promise/src/index.js
@@ -21,8 +21,7 @@ function fetchUserInfo(userId) {
 }
 
 function getUserId() {
-    const value = document.getElementById("userId").value;
-    return encodeURIComponent(value);
+    return document.getElementById("userId").value;
 }
 
 function createView(userInfo) {

--- a/source/use-case/ajaxapp/src/index.js
+++ b/source/use-case/ajaxapp/src/index.js
@@ -1,6 +1,5 @@
 function getUserId() {
-    const value = document.getElementById("userId").value;
-    return encodeURIComponent(value);
+    return document.getElementById("userId").value;
 }
 
 function fetchUserInfo(userId) {


### PR DESCRIPTION
Fix #1207

本文中では触れていなかったのでサンプルコードのみ。