### PR TITLE
feat(website): change bug report word

### DIFF
--- a/book.json
+++ b/book.json
@@ -38,7 +38,8 @@
       "index": "asciidwango"
     },
     "github-issue-feedback": {
-      "repo": "asciidwango/js-primer"
+      "repo": "asciidwango/js-primer",
+      "label": "問題を報告する"
     },
     "edit-link": {
       "base": "https://github.com/asciidwango/js-primer/edit/master/source/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2423,9 +2423,9 @@
       }
     },
     "@textlint/markdown-to-ast": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.6.tgz",
-      "integrity": "sha512-xIaMn6gW1Ig+M+2Xcdbxt4cgOqWJSuB0pIO98KppQyqPzQ5k5deea7SBABqLZiKeNIxLl+2C1vfIfnBFFjxlmg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.7.tgz",
+      "integrity": "sha512-B0QtokeQR4a9+4q0NQr8T9l7A1fFihTN5Ze57tVgqW+3ymzXEouh8DvPHeNQ4T6jEkAThvdjk95mxAMpGRJ79w==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^4.2.5",
@@ -6864,9 +6864,9 @@
       "dev": true
     },
     "gitbook-plugin-github-issue-feedback": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/gitbook-plugin-github-issue-feedback/-/gitbook-plugin-github-issue-feedback-1.3.4.tgz",
-      "integrity": "sha512-JRdsbV4whSFfsvjMQhEXl8lnFTe2Pk+k3z5Kcyvcl2urxAK6lkrYJhKach5u9MB14VCabBPazUXSIwyVuwwv4w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-github-issue-feedback/-/gitbook-plugin-github-issue-feedback-1.4.0.tgz",
+      "integrity": "sha512-B5JdZjSDH64BOqRwmB1FxAKC96RXbe3Lib5FvLeF+qyckcJCEUFcQ5iyDwEBFk/BciStFyZDto02OtAKy7h1Ew==",
       "dev": true,
       "requires": {
         "fs-extra": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gitbook-plugin-canonical-link": "^2.0.3",
     "gitbook-plugin-custom-favicon": "0.0.4",
     "gitbook-plugin-ga": "^1.0.0",
-    "gitbook-plugin-github-issue-feedback": "^1.3.4",
+    "gitbook-plugin-github-issue-feedback": "^1.4.0",
     "gitbook-plugin-include-codeblock": "^3.2.2",
     "gitbook-plugin-js-console": "^2.0.5",
     "gitbook-plugin-page-toc-button": "^0.1.1",


### PR DESCRIPTION
## 概要
JavaScript Primer のウェブサイト版（https://jsprimer.net/） 画面右下の
「Bug Report」の文言を「問題を報告する」に変更しました。
このissue（https://github.com/asciidwango/js-primer/issues/1209） の対応です。

ご確認よろしくお願いします。
