### PR TITLE
正規表現リテラルのサンプルコードの修正

### DIFF
--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -460,7 +460,7 @@ JavaScriptは正規表現をリテラルで書くことができます。
 ```js
 const numberRegExp = /\d+/; // 1文字以上の数字にマッチする正規表現
 // `numberRegExp`の正規表現が文字列"123"にマッチするかをテストする
-console.log(numberRegExp.test(123)); // => true
+console.log(numberRegExp.test("123")); // => true
 ```
 
 `RegExp`コンストラクタを使うことで、文字列から正規表現オブジェクトを作成できます。

--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -459,7 +459,7 @@ JavaScriptは正規表現をリテラルで書くことができます。
 {{book.console}}
 ```js
 const numberRegExp = /\d+/; // 1文字以上の数字にマッチする正規表現
-// 数値123を文字列"123"に変換してから正規表現にマッチするかをテストする
+// `numberRegExp`の正規表現が文字列"123"にマッチするかをテストする
 console.log(numberRegExp.test(123)); // => true
 ```
 

--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -459,7 +459,7 @@ JavaScriptは正規表現をリテラルで書くことができます。
 {{book.console}}
 ```js
 const numberRegExp = /\d+/; // 1文字以上の数字にマッチする正規表現
-// 123が正規表現にマッチするかをテストする
+// 数値123を文字列"123"に変換してから正規表現にマッチするかをテストする
 console.log(numberRegExp.test(123)); // => true
 ```
 


### PR DESCRIPTION
RegExp.prototype.test() は文字列を扱います。
このサンプルだと数値の字面をそのまま扱うように勘違いする可能性がありそうで、文字列に変換されるステップを記載しました。

例えば /64/.test(0x64) のように見た目は 同じ64 でも false になる場合などです。