### PR TITLE
fix(nodecli): 末尾の改行コードを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:example": "mocha test/",
     "test:basic": "mocha \"./source/basic/**/*-test.js\"",
     "test:nodecli": "cd ./source/use-case/nodecli && npm install && npm test",
+    "test:nodecli-unittest": "cd ./source/use-case/nodecli/refactor-and-unittest/src/test && npm install && npm test",
     "test:ajaxapp": "mocha \"./source/use-case/ajaxapp/!(node_modules)**/*-test.js\"",
     "test:todoapp": "cd ./source/use-case/todoapp && npm install && npm test",
     "test": "npm-run-all -l --parallel test:* lint",

--- a/source/use-case/nodecli/refactor-and-unittest/src/test/md2html-test.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/test/md2html-test.js
@@ -8,13 +8,13 @@ it("converts Markdown to HTML (GFM=false)", () => {
     const sample = fs.readFileSync(path.resolve(__dirname, "./fixtures/sample.md"), { encoding: "utf8" });
     const expected = fs.readFileSync(path.resolve(__dirname, "./fixtures/expected.html"), { encoding: "utf8" });
 
-    assert.strictEqual(md2html(sample, { gfm: false }), expected);
+    assert.strictEqual(md2html(sample, { gfm: false }).trim(), expected);
 });
 
 it("converts Markdown to HTML (GFM=true)", () => {
     const sample = fs.readFileSync(path.resolve(__dirname, "./fixtures/sample.md"), { encoding: "utf8" });
     const expected = fs.readFileSync(path.resolve(__dirname, "./fixtures/expected-gfm.html"), { encoding: "utf8" });
 
-    assert.strictEqual(md2html(sample, { gfm: true }), expected);
+    assert.strictEqual(md2html(sample, { gfm: true }).trim(), expected);
 });
 

--- a/source/use-case/nodecli/refactor-and-unittest/src/test/md2html-test.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/test/md2html-test.js
@@ -7,14 +7,14 @@ it("converts Markdown to HTML (GFM=false)", () => {
     // fs.readFileSyncは同期的にファイルを読み込むメソッド
     const sample = fs.readFileSync(path.resolve(__dirname, "./fixtures/sample.md"), { encoding: "utf8" });
     const expected = fs.readFileSync(path.resolve(__dirname, "./fixtures/expected.html"), { encoding: "utf8" });
-
-    assert.strictEqual(md2html(sample, { gfm: false }).trim(), expected);
+    // 末尾の改行の有無の違いを無視するため、変換後のHTMLのスペースをtrimメソッドで削除してから比較しています
+    assert.strictEqual(md2html(sample, { gfm: false }).trimEnd(), expected.trimEnd());
 });
 
 it("converts Markdown to HTML (GFM=true)", () => {
     const sample = fs.readFileSync(path.resolve(__dirname, "./fixtures/sample.md"), { encoding: "utf8" });
     const expected = fs.readFileSync(path.resolve(__dirname, "./fixtures/expected-gfm.html"), { encoding: "utf8" });
-
-    assert.strictEqual(md2html(sample, { gfm: true }).trim(), expected);
+    // 末尾の改行の有無の違いを無視するため、変換後のHTMLのスペースをtrimメソッドで削除してから比較しています
+    assert.strictEqual(md2html(sample, { gfm: true }).trimEnd(), expected.trimEnd());
 });
 


### PR DESCRIPTION
https://github.com/asciidwango/js-primer/issues/1233