### PR TITLE
Array#sliceにおいて空配列となる場合の引数の条件を修正

### DIFF
--- a/source/basic/array/README.md
+++ b/source/basic/array/README.md
@@ -310,7 +310,9 @@ console.log(array.slice(1, 4)); // => ["B", "C", "D"]
 console.log(array.slice(1)); // => ["B", "C", "D", "E"]
 // マイナスを指定すると後ろからの数えた位置となる
 console.log(array.slice(-1)); // => ["E"]
-// 第一引数 >= 第二引数の場合、常に空配列を返す
+// 第一引数と第二引数が同じ場合は、空の配列を返す
+console.log(array.slice(1, 1)); // => []
+// 第一引数 > 第二引数の場合、常に空配列を返す
 console.log(array.slice(4, 1)); // => []
 ```
 

--- a/source/basic/array/README.md
+++ b/source/basic/array/README.md
@@ -310,7 +310,7 @@ console.log(array.slice(1, 4)); // => ["B", "C", "D"]
 console.log(array.slice(1)); // => ["B", "C", "D", "E"]
 // マイナスを指定すると後ろからの数えた位置となる
 console.log(array.slice(-1)); // => ["E"]
-// 第一引数 > 第二引数の場合、常に空配列を返す
+// 第一引数 >= 第二引数の場合、常に空配列を返す
 console.log(array.slice(4, 1)); // => []
 ```
 


### PR DESCRIPTION
Array#sliceでは第一引数と第二引数が同一の場合も空配列となるので、
その意味も含めて`>`ではなく`>=`もしくは`≧`が良いと思います。

ささいな修正で恐縮ですが、上から読んでいった時に気になったので提案させて頂きました。
（このレベルならIssueの方が良い、等あればお教えください。）

過去の議論としては https://github.com/asciidwango/js-primer/issues/1163 とも関連すると思います。