### PR TITLE
Navigationリンクのmin-widthを調整

### DIFF
--- a/source/_layouts/website/page.html
+++ b/source/_layouts/website/page.html
@@ -77,6 +77,10 @@
             display: none;
         }
     }
+
+    .navigation {
+        min-width: 50px;
+    }
 </style>
 <meta name="theme-color" content="#ffffff">
 <link rel="manifest" href="{{ "/manifest.json"|resolveFile }}">


### PR DESCRIPTION
close #1253

見出しのリンクと被さってしまうことを回避するため、page.htmlに以下を追記しました。
`navigation-prev`だけスタイルをあてるとナビゲーション左右のバランスが崩れて見えるので両方に当てました。

```css
.navigation {
    min-width: 50px;
}
```

▼修正前
![スクリーンショット 2020-09-02 8 40 21](https://user-images.githubusercontent.com/33926355/91916393-fcc3f780-ecf7-11ea-8d35-3b3a7e90d253.png)

▼修正後
![スクリーンショット 2020-09-02 8 38 57](https://user-images.githubusercontent.com/33926355/91916313-ce461c80-ecf7-11ea-849b-256e874358bd.png)