### PR TITLE
不要なセミコロンを削除

### DIFF
--- a/source/basic/async/README.md
+++ b/source/basic/async/README.md
@@ -1666,7 +1666,7 @@ async function asyncMain() {
     await new Promise((resolve) => {
         setTimeout(resolve, 16);
     });
-};
+}
 console.log("1. asyncMain関数を呼び出します");
 // Async Functionは外から見れば単なるPromiseを返す関数
 asyncMain().then(() => {


### PR DESCRIPTION
こんにちは 👋 , js-primerには大変お世話になっています！
関数宣言の末尾にセミコロンが入っていたので削除しました。ご確認頂けると嬉しいです。