### PR TITLE
fix(website): 登録ボタンのコントラスト比の改善

### DIFF
--- a/source/landing/css/style.css
+++ b/source/landing/css/style.css
@@ -45,9 +45,14 @@ a, button {
     margin: 0 0 5px 5px;
 }
 
-.btn-d, .btn-d:hover, .btn-d:focus {
+.btn-d {
     color: #FFF;
-    background: rgba(0, 0, 0, .3);
+    background-color: rgba(51, 51, 51, .8);
+}
+
+.btn-d:hover, .btn-d:focus {
+    color: #FFF;
+    background-color: rgba(51, 51, 51, .68);
 }
 
 /* Prevent ugly blue glow on chrome and safari */

--- a/source/landing/index.html
+++ b/source/landing/index.html
@@ -70,7 +70,7 @@
                 <div class="form-group"><label for="email">メールアドレス</label><input id="email" class="form-control"
                                                                                  name="EMAIL" type="email" required/>
                 </div>
-                <button class="bloc-button btn btn-d btn-lg btn-block" type="submit">登録</button>
+                <button class="btn btn-d btn-lg btn-block" type="submit">登録</button>
             </form>
         </div>
         <div class="col-sm-4 hidden-xs">


### PR DESCRIPTION

## 概要

ランディングページに更新情報を購読できるフォームがあったので、登録させていただきました。
登録した際に、ボタンの文字色と背景色のコントラスト比が少し低いように感じたので修正しました。

現在のコントラスト比は 2.12 ですが、[Web Content Accessibility Guidelines](https://webaim.org/standards/wcag/) では 4.5 以上が推奨されているので、`hover` 時にそれを下回らない背景色に修正しました。

> WebAIM のガイドライン では、すべてのテキストで AA（最小）コントラスト比 4.5:1 を推奨しています。例外は、非常に大きなテキストです（デフォルトの本文テキストより 120～150% 大きい）。この場合、推奨されるコントラスト比は 3:1 です。
> ref: https://developers.google.com/web/fundamentals/accessibility/accessible-styles)

サイトの統一感を崩さないために、背景色は #1213 の「問題を報告する」ボタンに寄せました。

## Before
### 通常
![スクリーンショット 2020-09-21 13 20 29](https://user-images.githubusercontent.com/5207601/93732669-50e23d80-fc0d-11ea-9848-3d26f2092c50.png)

![now-btn](https://user-images.githubusercontent.com/5207601/93732234-6eaea300-fc0b-11ea-9652-c8940a73212c.png)

## After
### 通常
![スクリーンショット 2020-09-21 13 31 07](https://user-images.githubusercontent.com/5207601/93733065-d5818b80-fc0e-11ea-8c3d-d96e9c7ce796.png)
![スクリーンショット 2020-09-21 13 31 14](https://user-images.githubusercontent.com/5207601/93733066-d7e3e580-fc0e-11ea-88bd-becdf70fbc3e.png)

### :hover, :foucus
![スクリーンショット 2020-09-21 13 31 32](https://user-images.githubusercontent.com/5207601/93733067-d9ada900-fc0e-11ea-95e9-8fa0d4da18f3.png)
![スクリーンショット 2020-09-21 13 31 42](https://user-images.githubusercontent.com/5207601/93733069-db776c80-fc0e-11ea-95db-1d6d3008cc5f.png)