### PR TITLE
関数名の修正

### DIFF
--- a/source/basic/async/README.md
+++ b/source/basic/async/README.md
@@ -921,7 +921,7 @@ Promise.resolve().then(function onFulfilledA() {
 この`Promise`インスタンスを返す仕組みを使うことで、`catch`してもそのまま**Rejected**な状態を継続できます。
 
 次のコードでは`catch`メソッドでログを出力しつつ`Promise.reject`メソッドを使って**Rejected**な`Promise`インスタンスを返しています。
-これによって、`asyncFunction`で発生したエラーのログを取りながら、Promiseチェーンはエラーのまま処理を継続できます。
+これによって、`main`で発生したエラーのログを取りながら、Promiseチェーンはエラーのまま処理を継続できます。
 
 {{book.console}}
 ```js
@@ -930,7 +930,7 @@ function main() {
 }
 // mainはRejectedなPromiseを返す
 main().catch(error => {
-    // asyncFunctionで発生したエラーのログを出力する
+    // mainで発生したエラーのログを出力する
     console.log(error);
     // Promiseチェーンはそのままエラーを継続させる
     return Promise.reject(error);


### PR DESCRIPTION
`asyncFunction`という関数名を`main`という関数名に二箇所修正しました。
コミットを確認したところ、関数名を`asyncFunction`から`main`に変更した時に修正し忘れた箇所だと見受けられます。ご確認よろしくお願いします。
https://github.com/asciidwango/js-primer/commit/1175db5aa9d6155f639a14af4380b641f087107e#diff-53e6933bf18e9be7d446bf2e2a7f5a1b86734e88fa74523040834422516eaf61L943-R961
