### PR TITLE
markedパッケージのバージョンを1.0.0から最新の4.0.10へ更新

### DIFF
--- a/source/use-case/nodecli/argument-parse/src/package-lock.json
+++ b/source/use-case/nodecli/argument-parse/src/package-lock.json
@@ -1,8 +1,26 @@
 {
   "name": "nodecli",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "nodecli",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^5.0.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  },
   "dependencies": {
     "commander": {
       "version": "5.0.0",

--- a/source/use-case/nodecli/argument-parse/src/package-lock.json
+++ b/source/use-case/nodecli/argument-parse/src/package-lock.json
@@ -1,26 +1,8 @@
 {
   "name": "nodecli",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "nodecli",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "^5.0.0"
-      }
-    },
-    "node_modules/commander": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
-      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
-      "engines": {
-        "node": ">= 6"
-      }
-    }
-  },
   "dependencies": {
     "commander": {
       "version": "5.0.0",

--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -14,7 +14,7 @@ JavaScriptでMarkdownをHTMLへ変換するために、今回は[marked][]とい
 markedのパッケージはnpmで配布されているので、commanderと同様に`npm install`コマンドでパッケージをインストールしましょう。
 
 ```shell
-$ npm install marked@1.0.0
+$ npm install marked@4.0.10
 ```
 
 インストールが完了したら、Node.jsのスクリプトから読み込みます。

--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -20,7 +20,7 @@ $ npm install marked@4.0.10
 インストールが完了したら、Node.jsのスクリプトから読み込みます。
 前のセクションの最後で書いたスクリプトに、markedパッケージの読み込み処理を追加しましょう。
 次のように`main.js`を変更し、読み込んだMarkdownファイルをmarkedを使ってHTMLに変換します。
-markedパッケージをインポートした`marked`関数は、Markdown文字列を引数にとり、HTML文字列に変換して返します。
+markedパッケージをインポートした`marked.parse`関数は、Markdown文字列を引数にとり、HTML文字列に変換して返します。
 
 [import title:"main.js"](src/main-1.js)
 
@@ -114,7 +114,7 @@ const cliOptions = {
 };
 ```
 
-こうして作成した`cliOptions`オブジェクトから、markedにオプションを渡しましょう。
+こうして作成したcliOptionsオブジェクトを、markedの`parse`関数へオプションとして渡しましょう。 main.jsの全体は次のようになります。
 `main.js`の全体は次のようになります。
 
 [import title:"main.js"](src/main-3.js)

--- a/source/use-case/nodecli/md-to-html/src/main-1.js
+++ b/source/use-case/nodecli/md-to-html/src/main-1.js
@@ -13,6 +13,6 @@ fs.readFile(filePath, { encoding: "utf8" }, (err, file) => {
         return;
     }
     // MarkdownファイルをHTML文字列に変換する
-    const html = marked(file);
+    const html = marked.parse(file);
     console.log(html);
 });

--- a/source/use-case/nodecli/md-to-html/src/main-2.js
+++ b/source/use-case/nodecli/md-to-html/src/main-2.js
@@ -12,7 +12,7 @@ fs.readFile(filePath, { encoding: "utf8" }, (err, file) => {
         return;
     }
     // gfmオプションを無効にする
-    const html = marked(file, {
+    const html = marked.parse(file, {
         gfm: false
     });
     console.log(html);

--- a/source/use-case/nodecli/md-to-html/src/main-3.js
+++ b/source/use-case/nodecli/md-to-html/src/main-3.js
@@ -21,7 +21,7 @@ fs.readFile(filePath, { encoding: "utf8" }, (err, file) => {
         process.exit(1);
         return;
     }
-    const html = marked(file, {
+    const html = marked.parse(file, {
         // オプションの値を使用する
         gfm: cliOptions.gfm,
     });

--- a/source/use-case/nodecli/md-to-html/src/main.js
+++ b/source/use-case/nodecli/md-to-html/src/main.js
@@ -21,7 +21,7 @@ fs.readFile(filePath, { encoding: "utf8" }, (err, file) => {
         process.exit(1);
         return;
     }
-    const html = marked(file, {
+    const html = marked.parse(file, {
         // オプションの値を使用する
         gfm: cliOptions.gfm,
     });

--- a/source/use-case/nodecli/md-to-html/src/package-lock.json
+++ b/source/use-case/nodecli/md-to-html/src/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
     },
     "marked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     }
   }
 }

--- a/source/use-case/nodecli/md-to-html/src/package.json
+++ b/source/use-case/nodecli/md-to-html/src/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^5.0.0",
-    "marked": "^1.0.0"
+    "marked": "^4.0.10"
   }
 }

--- a/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/main-last.js
@@ -19,7 +19,7 @@ fs.readFile(filePath, { encoding: "utf8" }, (err, file) => {
         process.exit(1);
         return;
     }
-    const html = marked(file, {
+    const html = marked.parse(file, {
         // オプションの値を使用する
         gfm: cliOptions.gfm,
     });

--- a/source/use-case/nodecli/refactor-and-unittest/src/md2html.js
+++ b/source/use-case/nodecli/refactor-and-unittest/src/md2html.js
@@ -1,7 +1,7 @@
 const marked = require("marked");
 
 module.exports = (markdown, cliOptions) => {
-    return marked(markdown, {
+    return marked.parse(markdown, {
         gfm: cliOptions.gfm,
     });
 };

--- a/source/use-case/nodecli/refactor-and-unittest/src/package-lock.json
+++ b/source/use-case/nodecli/refactor-and-unittest/src/package-lock.json
@@ -506,9 +506,9 @@
       }
     },
     "marked": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/source/use-case/nodecli/refactor-and-unittest/src/package.json
+++ b/source/use-case/nodecli/refactor-and-unittest/src/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^5.0.0",
-    "marked": "1.0.0"
+    "marked": "^4.0.10"
   },
   "devDependencies": {
     "mocha": "^7.0.0"


### PR DESCRIPTION
fix #1377 
md-to-htmlとrefactor-and-unittestで利用しているmarkedのバージョンを最新の4系へ更新しました。
それに伴って関数の呼び出しが `marked(html)` -> `marked.parse(html)` へ変更されたので置換して、testが通ることを確認しました。