### PR TITLE
chore: add links of strict mode

### DIFF
--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -169,7 +169,7 @@ console.log(0o777);  // => 511
 
 次のように、`0`からはじまり、`0`から`7`の数字を組み合わせた場合も8進数として扱われます。
 しかし、この表記は10進数と紛らわしいものであったため、ES2015で`0o`の8進数リテラルが新たに導入されました。
-また、strict modeではこの書き方は例外が発生するため、次のような8進数の書き方は避けるべきです（「[JavaScriptとは][]」の[strict mode][]を参照）。
+また、strict modeではこの書き方は例外が発生するため、次のような8進数の書き方は避けるべきです（詳細は「[JavaScriptとは][]」の[strict mode][]を参照）。
 
 {{book.console}}
 [import, octal-legacy-literal-invalid.js](./src/octal-legacy-literal-invalid.js)

--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -169,7 +169,7 @@ console.log(0o777);  // => 511
 
 次のように、`0`からはじまり、`0`から`7`の数字を組み合わせた場合も8進数として扱われます。
 しかし、この表記は10進数と紛らわしいものであったため、ES2015で`0o`の8進数リテラルが新たに導入されました。
-また、strict modeではこの書き方は例外が発生するため、次のような8進数の書き方は避けるべきです。
+また、strict modeではこの書き方は例外が発生するため、次のような8進数の書き方は避けるべきです（「[JavaScriptとは][]」の[strict mode][]を参照）。
 
 {{book.console}}
 [import, octal-legacy-literal-invalid.js](./src/octal-legacy-literal-invalid.js)
@@ -614,3 +614,5 @@ console.log(str.length); // => 3
 [配列]: ../array/README.md
 [オブジェクト]: ../object/README.md
 [ラッパーオブジェクト]: ../wrapper-object/README.md
+[JavaScriptとは]: ../introduction/README.md
+[strict mode]: ../introduction/README.md#strict-mode

--- a/source/basic/function-this/README.md
+++ b/source/basic/function-this/README.md
@@ -268,7 +268,7 @@ function outer() {
 outer();
 ```
 
-この書籍では注釈がないコードはstrict modeとして扱いますが、コード例に`"use strict";`と改めてstrict modeを明示しています（「[JavaScriptとは][]」の[strict mode][]を参照）。
+この書籍では注釈がないコードはstrict modeとして扱いますが、コード例に`"use strict";`と改めてstrict modeを明示しています（詳細は「[JavaScriptとは][]」の[strict mode][]を参照）。
 なぜなら、strict modeではない状況で`this`が`undefined`の場合は、`this`がグローバルオブジェクトを参照するように変換される問題があるためです。
 
 strict modeは、このような意図しにくい動作を防止するために導入されています。

--- a/source/basic/function-this/README.md
+++ b/source/basic/function-this/README.md
@@ -268,7 +268,7 @@ function outer() {
 outer();
 ```
 
-この書籍では注釈がないコードはstrict modeとして扱いますが、コード例に`"use strict";`と改めてstrict modeを明示しています。
+この書籍では注釈がないコードはstrict modeとして扱いますが、コード例に`"use strict";`と改めてstrict modeを明示しています（「[JavaScriptとは][]」の[strict mode][]を参照）。
 なぜなら、strict modeではない状況で`this`が`undefined`の場合は、`this`がグローバルオブジェクトを参照するように変換される問題があるためです。
 
 strict modeは、このような意図しにくい動作を防止するために導入されています。
@@ -929,6 +929,7 @@ console.log(obj.method.call("THAT")); // => "THAT"
 
 [^1]: ES2015の仕様編集者であるAllen Wirfs-Brock氏もただの関数においては`this`を使うべきではないと述べている。<https://twitter.com/awbjs/status/938272440085446657>;
 [JavaScriptとは]: ../introduction/README.md
+[strict mode]: ../introduction/README.md#strict-mode
 [関数と宣言]: ../function-declaration/README.md
 [クラス]: ../class/README.md
 [関数とスコープ]: ../function-scope/README.md

--- a/source/basic/object/README.md
+++ b/source/basic/object/README.md
@@ -340,7 +340,7 @@ obj = {}; // => SyntaxError
 作成したオブジェクトのプロパティの変更を防止するには`Object.freeze`メソッドを利用する必要があります。
 `Object.freeze`はオブジェクトを凍結します。凍結されたオブジェクトでプロパティの追加や変更すると例外が発生するようになります。
 
-ただし、`Object.freeze`メソッドを利用する場合は必ずstrict modeと合わせて使います（「[JavaScriptとは][]」の[strict mode][]を参照）。
+ただし、`Object.freeze`メソッドを利用する場合は必ずstrict modeと合わせて使います（詳細は「[JavaScriptとは][]」の[strict mode][]を参照）。
 strict modeではない場合は、凍結されたオブジェクトのプロパティを変更しても例外が発生せずに単純に無視されます。
 
 {{book.console}}

--- a/source/basic/object/README.md
+++ b/source/basic/object/README.md
@@ -340,7 +340,7 @@ obj = {}; // => SyntaxError
 作成したオブジェクトのプロパティの変更を防止するには`Object.freeze`メソッドを利用する必要があります。
 `Object.freeze`はオブジェクトを凍結します。凍結されたオブジェクトでプロパティの追加や変更すると例外が発生するようになります。
 
-ただし、`Object.freeze`メソッドを利用する場合は必ずstrict modeと合わせて使います。
+ただし、`Object.freeze`メソッドを利用する場合は必ずstrict modeと合わせて使います（「[JavaScriptとは][]」の[strict mode][]を参照）。
 strict modeではない場合は、凍結されたオブジェクトのプロパティを変更しても例外が発生せずに単純に無視されます。
 
 {{book.console}}
@@ -930,3 +930,5 @@ JavaScriptの`Object`は他のオブジェクトのベースとなるオブジ�
 [const]: ../variables/README.md#const
 [ユースケース: Node.jsでCLIアプリケーション]: ../../use-case/nodecli/README.md
 [Map/Set]: ../map-and-set/README.md
+[JavaScriptとは]: ../introduction/README.md
+[strict mode]: ../introduction/README.md#strict-mode

--- a/source/basic/string/README.md
+++ b/source/basic/string/README.md
@@ -990,9 +990,8 @@ Stringメソッドで表現できることはStringメソッドで表現し、�
 そのため、文字列から一部の文字を削除するような操作はできません。
 
 つまり、`delete`演算子は文字列に対して利用できません。
-strict modeでは削除できないプロパティを削除しようとするとエラーが発生します
-（strict modeでない場合はエラーも発生せず単に無視されます）
-（「[JavaScriptとは][]」の[strict mode][]を参照）。
+strict modeでは、`delete`演算子で削除できないプロパティを削除しようとするとエラーが発生します。
+strict modeでない場合は、エラーも発生せず単に無視されます（詳細は「[JavaScriptとは][]」の[strict mode][]を参照）。
 
 {{book.console}}
 ```js

--- a/source/basic/string/README.md
+++ b/source/basic/string/README.md
@@ -991,7 +991,8 @@ Stringメソッドで表現できることはStringメソッドで表現し、�
 
 つまり、`delete`演算子は文字列に対して利用できません。
 strict modeでは削除できないプロパティを削除しようとするとエラーが発生します
-（strict modeでない場合はエラーも発生せず単に無視されます）。
+（strict modeでない場合はエラーも発生せず単に無視されます）
+（「[JavaScriptとは][]」の[strict mode][]を参照）。
 
 {{book.console}}
 ```js
@@ -1279,7 +1280,6 @@ console.log(escapedURL); // => "https://example.com/search?q=A%26B&sort=desc"
 それらの文字列を安全に扱うためには、コンテキストに応じた処理が必要になります。
 また、タグつきテンプレートリテラルを利用することで、テンプレート中の変数を自動でエスケープするといった処理を実現できます。
 
-
 [文字列とUnicode]: ../string-unicode/README.md
 [ループと反復処理]: ../loop/README.md
 [エスケープシーケンス]: https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String#%E3%82%A8%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%97%E3%82%B7%E3%83%BC%E3%82%B1%E3%83%B3%E3%82%B9
@@ -1291,5 +1291,7 @@ console.log(escapedURL); // => "https://example.com/search?q=A%26B&sort=desc"
 [URL Standard]: https://url.spec.whatwg.org/  "URL Standard"
 [URL]: https://developer.mozilla.org/ja/docs/Web/API/URL  "URL - Web API インターフェイス | MDN"
 [Path]: https://nodejs.org/api/path.html  "Path | Node.js v7.9.0 Documentation"
+[JavaScriptとは]: ../introduction/README.md
+[strict mode]: ../introduction/README.md#strict-mode
 
 [^1]: Unicodeのカタカナの一覧 <https://unicode-table.com/jp/#katakana> から取り出したテーブルです。


### PR DESCRIPTION
Closes #807

- 各 `README.md` における `strict mode` の初出箇所にリンクを追加

対象:

```console
kangetsu@ubuntu20:~/work/js-primer$ grep -rli 'strict mode' ./source/ | grep README.md | grep -v introduction
./source/basic/object/README.md
./source/basic/string/README.md
./source/basic/data-type/README.md
./source/basic/function-this/README.md
kangetsu@ubuntu20:~/work/js-primer$ 
```