### PR TITLE
`NaN`になってしまった場合の処理をより明確にする

### DIFF
--- a/source/basic/implicit-coercion/README.md
+++ b/source/basic/implicit-coercion/README.md
@@ -330,8 +330,8 @@ Number(undefined); // => NaN
 ```js
 const userInput = "任意の文字列";
 const num = Number.parseInt(userInput, 10);
-if (!Number.isNaN(num)) {
-    console.log("NaNではない値にパースできた", num);
+if (Number.isNaN(num)) {
+    console.log("パースした結果NaNになった", num);
 }
 ```
 


### PR DESCRIPTION
Closes #1410

[暗黙的な型変換 | 文字列 → 数値](https://jsprimer.net/basic/implicit-coercion/#string-to-number) で、コードの内容を説明文に沿ったものにする