### PR TITLE
サンプルコードの「底関数」を「床関数」に変更しました

### DIFF
--- a/source/basic/math/README.md
+++ b/source/basic/math/README.md
@@ -88,7 +88,7 @@ console.log(Math.min(...numbers)); // => 1
 
 {{book.console}}
 ```js
-// 底関数
+// 床関数
 console.log(Math.floor(1.3)); // => 1
 console.log(Math.floor(-1.3)); // => -2
 // 天井関数


### PR DESCRIPTION
## 概要
80行目の文章では「床関数」と記載されているのに、その下のサンプルコードでは、「底関数」と記載されていました。
- #1243 で、「床関数」のほうが正しいと判断し、「床関数」に変更いたしました。