### PR TITLE
chore(basic/data-type): replace unnecessary var with const

### DIFF
--- a/source/basic/data-type/README.md
+++ b/source/basic/data-type/README.md
@@ -415,7 +415,7 @@ console.log(foo); // => null
 {{book.console}}
 ```js
 function fn(){
-    var undefined = "独自の未定義値"; // undefinedという名前の変数をエラーなく定義できる
+    const undefined = "独自の未定義値"; // undefinedという名前の変数をエラーなく定義できる
     console.log(undefined); // => "独自の未定義値"
 }
 fn();
@@ -477,7 +477,7 @@ console.log(obj["key"]); // => "value"
 {{book.console}}
 ```Js
 // プロパティ名は文字列の"123"
-var object = {
+const object = {
     "123": "value"
 };
 // OK: ブラケット記法では、文字列として書くことができる

--- a/source/basic/data-type/src/var-null-invalid.js
+++ b/source/basic/data-type/src/var-null-invalid.js
@@ -1,1 +1,1 @@
-var null; // => SyntaxError
+const null; // => SyntaxError

--- a/source/basic/data-type/src/var-null-invalid.js
+++ b/source/basic/data-type/src/var-null-invalid.js
@@ -1,1 +1,1 @@
-const null; // => SyntaxError
+let null; // => SyntaxError


### PR DESCRIPTION
`var` を使う必要がない (巻き上げなどの挙動が不要) 場面での `var` を `const` に置換しました

`var` の利用が意図的であればお手数ですがクローズお願いします。
使える箇所では `const` がより良いと考えているため `const` にしましたが、`let` の方が良いなどあれば修正いたします。

動作、`npm test` は確認済みです。