### PR TITLE
fix: Atomの言及を削除

### DIFF
--- a/source/appendix/links/README.md
+++ b/source/appendix/links/README.md
@@ -83,11 +83,6 @@ JavaScriptやHTML、CSSなどのコーディングに適したエディターを
 [VSCode][]はMicrosoft社がオープンソースで開発している無料のコードエディターです。
 JavaScriptによってプラグインを書くことができ、さまざまな機能を追加できます。
 
-#### Atom {#atom}
-
-[Atom][]はGitHub社がオープンソースで開発している無料のコードエディターです。
-VSCodeと同じようにプラグインによる拡張性が高く、GitHubと連携した機能が特徴です。
-
 ### ブラウザの開発者ツール {#browser-devtools}
 
 多くのブラウザは開発者向けの組み込みツールを提供しており、本編で紹介したコンソールもその一部です。
@@ -205,5 +200,5 @@ NW.jsはブラウザの中からNode.jsの開発エコシステムを直接利�
 [Google Cloud Functions]: https://cloud.google.com/functions/
 [Function as a Service]: https://en.wikipedia.org/wiki/Function_as_a_service
 
-[Electron]: https://electronjs.org/
+[Electron]: https://www.electronjs.org/
 [NW.js]: https://nwjs.io/

--- a/source/basic/read-eval-print/README.md
+++ b/source/basic/read-eval-print/README.md
@@ -106,7 +106,7 @@ REPLはあくまで開発者向けの機能です。
 ここでは、HTMLとJavaScriptファイルを使ったJavaScriptコードの実行方法を見ていきます。
 
 HTMLファイルとJavaScriptファイルの2種類を使い、JavaScriptのコードを実行する準備をしていきます。
-ファイルを作成するため[Atom][]や[Visual Studio Code][]などのJavaScriptに対応したエディターを用意しておくとスムーズです。
+ファイルを作成するため[Visual Studio Code][]などのJavaScriptに対応したエディターを用意しておくとスムーズです。
 エディターはどんなものでも問題ありませんが、必ず文字コード（エンコーディング）は**UTF-8**、改行コードは**LF**にしてファイルを保存してください。
 
 ファイルを作成するディレクトリはどんな場所でも問題ありませんが、ここでは`example`という名前のディレクトリにファイルを作成していきます。
@@ -342,7 +342,6 @@ JavaScriptにおいては多くのエラーはすでに類似するケースが�
 
 [Firefox]: https://www.mozilla.org/ja/firefox/
 [Webコンソールを開く]: https://developer.mozilla.org/ja/docs/Tools/Web_Console/Opening_the_Web_Console
-[Atom]: https://atom.io/
 [Visual Studio Code]: https://code.visualstudio.com/
 [Google]: https://www.google.com/
 [Stack Overflow]: https://stackoverflow.com/

--- a/source/use-case/setup-local-env/README.md
+++ b/source/use-case/setup-local-env/README.md
@@ -184,7 +184,7 @@ npmでは、すでに多種多様なローカルサーバーモジュールが�
 
 [Node.js]: https://nodejs.org/ja/
 [V8]: https://developers.google.com/v8/
-[Electron]: http://electron.atom.io/
+[Electron]: https://www.electronjs.org/
 [ダウンロードページ]: https://nodejs.org/ja/download/
 [npm]: https://www.npmjs.com/
 [npmのGitHubリポジトリ]: https://github.com/npm/cli


### PR DESCRIPTION
Atomは公式に非推奨となったため。

> On December 15, 2022, we will archive the atom/atom repository and all other repositories remaining in the Atom organization.
> [Sunsetting Atom | The GitHub Blog](https://github.blog/2022-06-08-sunsetting-atom/)


fix #1461

