### PR TITLE
非同期処理:Promise/Async Function内の誤字と思われる箇所を修正

### DIFF
--- a/source/basic/async/README.md
+++ b/source/basic/async/README.md
@@ -1692,7 +1692,7 @@ fetchResources(resources).then((results) => {
 
 ### [ES2022] Module直下での`await`式 {#top-level-await-in-module}
 
-ES2021までは、`await`式はAsync Functionの直下でのみ利用な可能なことを紹介しました。
+ES2021までは、`await`式はAsync Functionの直下でのみ利用可能なことを紹介しました。
 ES2022には、これに加えてModuleの直下ではAsync Functionで囲まなくても`await`式が利用できます。
 
 最初に「[JavaScriptとは][]」の章において、JavaScriptには実行コンテキストとして"Script"と"Module"があるという話をしました。


### PR DESCRIPTION
以下の非同期処理:Promise/Async Function内に誤字と思われる箇所があったので、

> [ES2022] Module直下でのawait式
> ES2021までは、await式はAsync Functionの直下でのみ利用な可能なことを紹介しました。 ES2022には、これに加えてModuleの直下ではAsync Functionで囲まなくてもawait式が利用できます。
> https://jsprimer.net/basic/async/#top-level-await-in-module

「利用な可能なこと -> 利用可能なこと」に修正しました。