### PR TITLE
fix: Node.js v18.12.0 LTSにアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ IssueやPull Requestについては、次のページを参照してください
 
     npm install
 
-Node.js 16.18.0以上とnpm 8.19.2以上が必要です。
+Node.js v18.12.0以上とnpm 8.19.2以上が必要です。
 
 ```
 $ node -v
-16.18.0
+v18.12.0
 $ npm -v
 8.19.2
 ```
@@ -150,5 +150,5 @@ jsprimerプロジェクトは次のメンバーで構成されています。
 ## OSS Supporters
 
 <a href="https://www.netlify.com">
-  <img src="https://www.netlify.com/img/global/badges/netlify-color-bg.svg"/>
+  <img src="https://www.netlify.com/img/global/badges/netlify-color-bg.svg" alt="Netlify"/>
 </a>

--- a/book.json
+++ b/book.json
@@ -21,7 +21,7 @@
   ],
   "variables": {
     "esversion": "2022",
-    "nodeversion": "16.18.0",
+    "nodeversion": "18.12.0",
     "npmversion": "8.19.2",
     "triplebackticks": "```",
     "console": "<a class=\"gitbook-plugin-js-console\" aria-hidden=\"true\"></a>"

--- a/meetings/2017-02-24/README.md
+++ b/meetings/2017-02-24/README.md
@@ -42,7 +42,7 @@
 - エラーオブジェクトは`error`で出すと考える人がいそう
 - @azu: Node.jsだと`console.error`って`stderr`に出力するんだっけ?
 - @laco: そうっぽい
-- https://nodejs.org/docs/latest-v16.x/api/console.html
+- https://nodejs.org/api/console.html
 - @azu: なるほど。
 - ならエラーは`stderr`にだすという意味で`console.error`使うのありそう
 - Console APIについては最初に解説入れるつもり

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "4.0.0",
   "description": "📖 JavaScript Primer - 迷わないための入門書",
-  "packageManager": "npm@8.15.0",
+  "packageManager": "npm@8.19.2",
   "type": "module",
   "directories": {
     "test": "test"

--- a/source/basic/ecmascript/README.md
+++ b/source/basic/ecmascript/README.md
@@ -188,6 +188,6 @@ ECMAScriptにおいては策定プロセスという形でどのような段階�
 [polyfill.io]: https://polyfill.io/v2/docs/  "Polyfill service"
 [MDN Web Docs]: https://developer.mozilla.org/ja/  "MDN Web Docs"
 [^1]: ECMAScript 4は複雑で大きな変更が含まれており、合意を得ることができずに仕様が破棄されました。
-[^2]: この策定プロセスは<https://tc39.github.io/process-document/>に詳細が書かれています。
+[^2]: この策定プロセスは<https://tc39.es/process-document/>に詳細が書かれています。
 [^3]: ES2015の仕様編集者であるAllen Wirfs-Brock氏の書いた[Programming Language Standardization](http://wirfs-brock.com/allen/files/papers/standpats-asianplop2016.pdf)に詳細が書かれています。
 [^4]: [Inactive Proposals](https://github.com/tc39/proposals/blob/main/inactive-proposals.md)に策定を中止したプロポーザルの一覧が公開されています。

--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -13,7 +13,7 @@ description: "コマンドライン引数を受け取り、アプリケーショ
 コマンドライン引数を扱う前に、まずは`process`オブジェクトについて触れておきます。
 `process`オブジェクトはNode.js実行環境のグローバル変数のひとつです。
 `process`オブジェクトが提供するのは、現在のNode.jsの実行プロセスについて、情報の取得と操作をするAPIです。
-詳細は[公式ドキュメント](https://nodejs.org/docs/latest-v16.x/api/process.html#process_process)を参照してください。
+詳細は[公式ドキュメント](https://nodejs.org/docs/latest-v18.x/api/process.html#process_process)を参照してください。
 
 コマンドライン引数へのアクセスを提供するのは、`process`オブジェクトの`argv`プロパティで、文字列の配列になっています。
 次のように`main.js`を変更し、`process.argv`をコンソールに出力しましょう。

--- a/source/use-case/nodecli/helloworld/README.md
+++ b/source/use-case/nodecli/helloworld/README.md
@@ -86,8 +86,8 @@ ECMAScriptで定義されているグローバルオブジェクトはブラウ�
 
 [document]: https://developer.mozilla.org/ja/docs/Web/API/Document
 [XMLHttpRequest]: https://developer.mozilla.org/ja/docs/Web/API/XMLHttpRequest
-[global]: https://nodejs.org/docs/latest-v16.x/api/globals.html
-[process]: https://nodejs.org/docs/latest-v16.x/api/process.html#process_process
-[Buffer]: https://nodejs.org/docs/latest-v16.x/api/buffer.html
+[global]: https://nodejs.org/docs/latest-v18.x/api/globals.html
+[process]: https://nodejs.org/docs/latest-v18.x/api/process.html#process_process
+[Buffer]: https://nodejs.org/docs/latest-v18.x/api/buffer.html
 
 [アプリケーション開発の準備]: ../../setup-local-env/README.md


### PR DESCRIPTION
[Node v18.12.0 (LTS) | Node.js](https://nodejs.org/en/blog/release/v18.12.0/) へアップデート

- [x] READMEの更新
- [x] Node.jsのドキュメントリンクを更新
- [x] book.jsonを更新
- [x] `npm run textlint-link` でリンク切れチェック

fix #1437 