### PR TITLE
fix(ajax): externalResourcesではなく、動的に末尾にglobalThisでグローバルに関数を追加した

### DIFF
--- a/source/use-case/ajaxapp/display/README.md
+++ b/source/use-case/ajaxapp/display/README.md
@@ -162,12 +162,13 @@ result.innerHTML = view;
 
 - <https://jsprimer.net/use-case/ajaxapp/display/src/>
 
-<!-- externalResourcesをサイト上のjsを読み込んでいるのでデプロイするまでローカルでは確認できない。これはSandpackの問題を回避するため https://github.com/honkit/honkit-plugin-sandpack#note -->
+<!-- sandpackの問題でindex.jsがscriptタグとは異なる読み方がされ、globalに関数が追加されない。そのためappendCodeでglobalThisに関数を追加する -->
 
 <!-- sandpack:{
   "files": {
     "/index.js": {
-      "path": "src/index.js"
+      "path": "src/index.js",
+      "appendCode": "/* この行は本編とは無関係であるため無視してください。 */ window.fetchUserInfo = fetchUserInfo;"
     },
     "/index.html": {
       "path": "src/index.html",
@@ -178,6 +179,8 @@ result.innerHTML = view;
       "hidden": true
     }
   },
+  "entry": "/index.js",
+  "main": "/index.js",
   "environment": "static",
   "template": "vanilla",
   "options": {

--- a/source/use-case/ajaxapp/entrypoint/README.md
+++ b/source/use-case/ajaxapp/entrypoint/README.md
@@ -120,7 +120,7 @@ JavaScriptとDOMはWebアプリケーション開発において切っても切�
 
 - <https://jsprimer.net/use-case/ajaxapp/entrypoint/src/>
 
-<!-- externalResourcesをサイト上のjsを読み込んでいるのでデプロイするまでローカルでは確認できない。これはSandpackの問題を回避するため https://github.com/honkit/honkit-plugin-sandpack#note -->
+<!-- sandpackの問題でindex.jsがscriptタグとは異なる読み方がされ、globalに関数が追加されない。そのためappendCodeでglobalThisに関数を追加する -->
 
 <!-- sandpack:{
   "files": {

--- a/source/use-case/ajaxapp/http/README.md
+++ b/source/use-case/ajaxapp/http/README.md
@@ -183,12 +183,13 @@ XHRの詳しい使い方については、[XHRの利用についてのドキュ�
 
 - <https://jsprimer.net/use-case/ajaxapp/http/src/>
 
-<!-- externalResourcesをサイト上のjsを読み込んでいるのでデプロイするまでローカルでは確認できない。これはSandpackの問題を回避するため https://github.com/honkit/honkit-plugin-sandpack#note -->
+<!-- sandpackの問題でindex.jsがscriptタグとは異なる読み方がされ、globalに関数が追加されない。そのためappendCodeでglobalThisに関数を追加する -->
 
 <!-- sandpack:{
   "files": {
     "/index.js": {
-      "path": "src/index.js"
+      "path": "src/index.js",
+      "appendCode": "/* この行は本編とは無関係であるため無視してください。 */ window.fetchUserInfo = fetchUserInfo;"
     },
     "/index.html": {
       "path": "src/index.html",
@@ -199,12 +200,13 @@ XHRの詳しい使い方については、[XHRの利用についてのドキュ�
       "hidden": true
     }
   },
+  "entry": "/index.js",
+  "main": "/index.js",
   "environment": "static",
   "template": "vanilla",
   "options": {
     "showLineNumbers": true,
     "editorHeight": 550,
-    "externalResources": ["https://jsprimer.net/use-case/ajaxapp/http/src/index.js"],
     "showConsole": true, 
     "showConsoleButton": true 
   },

--- a/source/use-case/ajaxapp/promise/README.md
+++ b/source/use-case/ajaxapp/promise/README.md
@@ -208,12 +208,13 @@ index.jsにも`<input>`タグから値を受け取るための処理を追加す
 
 - <https://jsprimer.net/use-case/ajaxapp/promise/src/>
 
-<!-- externalResourcesをサイト上のjsを読み込んでいるのでデプロイするまでローカルでは確認できない。これはSandpackの問題を回避するため https://github.com/honkit/honkit-plugin-sandpack#note -->
+<!-- sandpackの問題でindex.jsがscriptタグとは異なる読み方がされ、globalに関数が追加されない。そのためappendCodeでglobalThisに関数を追加する -->
 
 <!-- sandpack:{
   "files": {
     "/index.js": {
-      "path": "src/index.js"
+      "path": "src/index.js",
+      "appendCode": "/* この行は本編とは無関係であるため無視してください。 */ window.main = main;"
     },
     "/index.html": {
       "path": "src/index.html",
@@ -224,6 +225,8 @@ index.jsにも`<input>`タグから値を受け取るための処理を追加す
       "hidden": true
     }
   },
+  "entry": "/index.js",
+  "main": "/index.js",
   "environment": "static",
   "template": "vanilla",
   "options": {


### PR DESCRIPTION
`globalThis.fetchUserInfo = fetchUserInfo;` を末尾に動的に作って追加することで、onclick="fetchUserInfo()" が動くようにした

fix https://github.com/asciidwango/js-primer/pull/1423
fix https://github.com/asciidwango/js-primer/issues/1520