### PR TITLE
fix(todoapp): <ul /> を <ul></ul> に変更

### DIFF
--- a/source/use-case/todoapp/event-model/event-emitter/src/App.js
+++ b/source/use-case/todoapp/event-model/event-emitter/src/App.js
@@ -14,7 +14,7 @@ export class App {
         // 2. TodoListModelの状態が更新されたら表示を更新する
         this.#todoListModel.onChange(() => {
             // TodoリストをまとめるList要素
-            const todoListElement = element`<ul />`;
+            const todoListElement = element`<ul></ul>`;
             // それぞれのTodoItem要素をtodoListElement以下へ追加する
             const todoItems = this.#todoListModel.getTodoItems();
             todoItems.forEach(item => {

--- a/source/use-case/todoapp/final/create-view/src/view/TodoListView.js
+++ b/source/use-case/todoapp/final/create-view/src/view/TodoListView.js
@@ -10,7 +10,7 @@ export class TodoListView {
      * @returns {Element} TodoItemModelの配列に対応したリストのHTML要素
      */
     createElement(todoItems, { onUpdateTodo, onDeleteTodo }) {
-        const todoListElement = element`<ul />`;
+        const todoListElement = element`<ul></ul>`;
         // 各TodoItemモデルに対応したHTML要素を作成し、リスト要素へ追加する
         todoItems.forEach(todoItem => {
             const todoItemView = new TodoItemView();

--- a/source/use-case/todoapp/final/final/src/view/TodoListView.js
+++ b/source/use-case/todoapp/final/final/src/view/TodoListView.js
@@ -10,7 +10,7 @@ export class TodoListView {
      * @returns {Element} TodoItemModelの配列に対応したリストのHTML要素
      */
     createElement(todoItems, { onUpdateTodo, onDeleteTodo }) {
-        const todoListElement = element`<ul />`;
+        const todoListElement = element`<ul></ul>`;
         // 各TodoItemモデルに対応したHTML要素を作成し、リスト要素へ追加する
         todoItems.forEach(todoItem => {
             const todoItemView = new TodoItemView();

--- a/source/use-case/todoapp/final/more/src/view/TodoListView.js
+++ b/source/use-case/todoapp/final/more/src/view/TodoListView.js
@@ -10,7 +10,7 @@ export class TodoListView {
      * @returns {Element} TodoItemModelの配列に対応したリストのHTML要素
      */
     createElement(todoItems, { onUpdateTodo, onDeleteTodo }) {
-        const todoListElement = element`<ul />`;
+        const todoListElement = element`<ul></ul>`;
         // 各TodoItemモデルに対応したHTML要素を作成し、リスト要素へ追加する
         todoItems.forEach(todoItem => {
             const todoItemView = new TodoItemView();

--- a/source/use-case/todoapp/form-event/add-todo-item/src/App.js
+++ b/source/use-case/todoapp/form-event/add-todo-item/src/App.js
@@ -7,7 +7,7 @@ export class App {
         const containerElement = document.querySelector("#js-todo-list");
         const todoItemCountElement = document.querySelector("#js-todo-count");
         // TodoリストをまとめるList要素
-        const todoListElement = element`<ul />`;
+        const todoListElement = element`<ul></ul>`;
         // Todoアイテム数
         let todoItemCount = 0;
         formElement.addEventListener("submit", (event) => {

--- a/source/use-case/todoapp/update-delete/add-checkbox/src/App.js
+++ b/source/use-case/todoapp/update-delete/add-checkbox/src/App.js
@@ -12,7 +12,7 @@ export class App {
         const todoItemCountElement = document.querySelector("#js-todo-count");
         //! [checkbox]
         this.#todoListModel.onChange(() => {
-            const todoListElement = element`<ul />`;
+            const todoListElement = element`<ul></ul>`;
             const todoItems = this.#todoListModel.getTodoItems();
             todoItems.forEach(item => {
                 // 完了済みならchecked属性をつけ、未完了ならchecked属性を外す

--- a/source/use-case/todoapp/update-delete/delete-feature/src/App.js
+++ b/source/use-case/todoapp/update-delete/delete-feature/src/App.js
@@ -12,7 +12,7 @@ export class App {
         const todoItemCountElement = document.querySelector("#js-todo-count");
         //! [checkbox]
         this.#todoListModel.onChange(() => {
-            const todoListElement = element`<ul />`;
+            const todoListElement = element`<ul></ul>`;
             const todoItems = this.#todoListModel.getTodoItems();
             todoItems.forEach(item => {
                 // 削除ボタン(x)をそれぞれ追加する

--- a/source/use-case/todoapp/update-delete/update-feature/src/App.js
+++ b/source/use-case/todoapp/update-delete/update-feature/src/App.js
@@ -12,7 +12,7 @@ export class App {
         const todoItemCountElement = document.querySelector("#js-todo-count");
         //! [checkbox]
         this.#todoListModel.onChange(() => {
-            const todoListElement = element`<ul />`;
+            const todoListElement = element`<ul></ul>`;
             const todoItems = this.#todoListModel.getTodoItems();
             todoItems.forEach(item => {
                 // 完了済みならchecked属性をつけ、未完了ならchecked属性を外す


### PR DESCRIPTION
`<ul />` は結果として動いてるけど、空の`<ul></ul>` を作るという意味では微妙にうまくいかないケースがあるため、 `<ul></ul>` に変更。

背景:

- `<ul />` → `<ul></ul>` に変更
- `<ul />` 自体の解説がない
- `<ul/> test` のように書くと意味が異なる

fix #1508 