### PR TITLE
fix: Removed redundant text

### DIFF
--- a/source/use-case/nodecli/md-to-html/README.md
+++ b/source/use-case/nodecli/md-to-html/README.md
@@ -114,8 +114,7 @@ const cliOptions = {
 };
 ```
 
-こうして作成したcliOptionsオブジェクトを、markedの`parse`関数へオプションとして渡しましょう。 main.jsの全体は次のようになります。
-`main.js`の全体は次のようになります。
+こうして作成したcliOptionsオブジェクトを、markedの`parse`関数へオプションとして渡しましょう。`main.js`の全体は次のようになります。
 
 [import title:"main.js"](src/main-3.js)
 


### PR DESCRIPTION
以下ページの誤記修正です。

MarkdownをHTMLに変換する
https://jsprimer.net/use-case/nodecli/md-to-html

同じ内容の文章が２回書かれていましたので、一方を削除しました。