### PR TITLE
fix: typo を修正

### DIFF
--- a/source/basic/variables/README.md
+++ b/source/basic/variables/README.md
@@ -68,7 +68,7 @@ const bookCategory = "プログラミング";
 `let`キーワードでは、値の再代入が可能な変数を宣言できます。
 `let`の使い方は`const`とほとんど同じです。
 
-次のコードでは、`bookTitle`という変数を宣言し、初期値を`"JavaScript Primer"`という文字列であることを定義しています。
+次のコードでは、`bookTitle`という変数を宣言し、初期値が`"JavaScript Primer"`という文字列であることを定義しています。
 
 ```js
 let bookTitle = "JavaScript Primer";


### PR DESCRIPTION
「初期値を」では文法的に少しおかしいため、「初期値が」へと修正しました。