### PR TITLE
fix: 開発者ツールのショートカットを修正

### DIFF
--- a/source/basic/read-eval-print/README.md
+++ b/source/basic/read-eval-print/README.md
@@ -47,7 +47,7 @@ REPL機能を使うことで、試したいコードをその場で実行でき�
 REPL機能を使うには、まずFirefoxの開発者ツールを次のいずれかの方法で開きます。
 
 - Firefox メニュー（メニューバーがある場合や macOS では、ツールメニュー）の "ブラウザーツール"のサブメニューから "ウェブ開発ツール" を選択する
-- キーボードショートカット Ctrl+Shift+K（macOS では Command+Option+K）を押下する
+- キーボードショートカット Ctrl+Shift+I（macOS では Command+Option+I）を押下する
 
 詳細は"[Firefox DevTools User Docs][]"を参照してください。
 


### PR DESCRIPTION
https://firefox-source-docs.mozilla.org/devtools-user/keyboard_shortcuts/index.html によると、

* Ctrl+Shift+I (macOS では Command+Option+I): 開発者ツールの表示
* Ctrl+Shift+K (macOS では Command+Option+K): Webコンソールの表示

となっているため、「開発者ツールを開く」という意味で正確なショートカットコマンドとしては K ではなく I だと考え、修正しました（K のままでもWebコンソールが開かれるため結果的には何の問題もないのですが、正確に対応するコマンドでないことが気になったため PR しました）。