### PR TITLE
fix typo

### DIFF
--- a/source/intro/preparation/README.md
+++ b/source/intro/preparation/README.md
@@ -21,7 +21,7 @@ JavaScriptのコードは、ブラウザがあれば実行できます。
 
 {% endif %}
 
-次のJavaScriptのサンプルコードを書き写して、ブラウザでJavaScriptを実行するところから初めてみましょう。
+次のJavaScriptのサンプルコードを書き写して、ブラウザでJavaScriptを実行するところから始めてみましょう。
 
 ## サンプルコード {#samplecode}
 


### PR DESCRIPTION
## 概要
技術的な部分ではなく、漢字の用法に対するtypoがありましたので修正しました。
「初めてみましょう」を「始めてみましょう」に修正しました。

https://jsprimer.net/intro/preparation/