### PR TITLE
fix: 9 の二進数表現の誤りを修正

### DIFF
--- a/source/basic/operator/README.md
+++ b/source/basic/operator/README.md
@@ -656,7 +656,7 @@ num << bit;
 {{book.console}}
 ```js
 console.log(     9 << 2); // => 36
-console.log(0b1111 << 2); // => 0b11_1100
+console.log(0b1001 << 2); // => 0b10_0100
 ```
 
 ### 右シフト演算子（`>>`） {#right-shift}


### PR DESCRIPTION
9 の二進数表現 (0b1001) とすべき（と思われる）コードが 15 (0b1111) になっていたため、修正しました。