### PR TITLE
constで定義したオブジェクトへの再代入で発生する例外を修正した

### DIFF
--- a/source/basic/object/README.md
+++ b/source/basic/object/README.md
@@ -339,7 +339,7 @@ JavaScriptの`const`は値を固定するのではなく、変数への再代入
 
 ```js
 const obj = { key: "value" };
-obj = {}; // => SyntaxError
+obj = {}; // => TypeError
 ```
 
 作成したオブジェクトのプロパティの変更を防止するには`Object.freeze`メソッドを利用する必要があります。


### PR DESCRIPTION
[オブジェクト#[コラム] constで定義したオブジェクトは変更可能](https://jsprimer.net/basic/object/#const-and-object)
ブラウザ環境やランタイム環境(Node)で確認したところ、再代入によって発生する例外はTypeErrorだったため修正しました。

参考:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/57053236/218594134-8c45d9a9-c879-42e7-951f-41fa110bd78b.png">
