### PR TITLE
Arrow Funcitonにおいて{}とreturnを省略できる場合の説明を修正した

### DIFF
--- a/source/basic/function-declaration/README.md
+++ b/source/basic/function-declaration/README.md
@@ -512,7 +512,7 @@ const fnD = (x, y) => { /* 仮引数が複数のとき */ };
 // 値の返し方
 // 次の２つの定義は同じ意味となる
 const mulA = x => { return x * x; }; // ブロックの中でreturn
-const mulB = x => x * x;            // 1行のみの場合はreturnとブロックを省略できる
+const mulB = x => x * x;            // 1つの式である場合はreturnとブロックを省略できる
 ```
 
 <!-- textlint-enable eslint -->


### PR DESCRIPTION
該当ページ: url: https://jsprimer.net/basic/function-declaration/#arrow-function
関数と宣言のArrow Functionの項で

```javascript
const mulB = x => x * x;            // 1行のみの場合はreturnとブロックを省略できる
```

とあるが、このコメント部分で1行というのは厳密には正しくない(反例として2行でも省略可能)ので上の説明に合わせて「1つの式」という文言に修正しました。ご検討ください。
