### PR TITLE
SyntaxErrorが出るサンプルコードで変数宣言の部分をvarからconstに変更した

### DIFF
--- a/source/basic/statement-expression/src/statement-not-expression-invalid.js
+++ b/source/basic/statement-expression/src/statement-not-expression-invalid.js
@@ -1,2 +1,2 @@
 // 構文として間違っているため、SyntaxErrorが発生する
-var forIsNotExpression = if (true) { /* ifは文であるため式にはなれない */ }
+const forIsNotExpression = if (true) { /* ifは文であるため式にはなれない */ }


### PR DESCRIPTION
「文と式」の[文](https://jsprimer.net/basic/statement-expression/#statement)の項において varを使っている理由は特段ないとのことだったので、推奨されているconstに変更しました。
この変更で本来伝えたいことには影響することはありません。

- refs : https://github.com/asciidwango/js-primer/discussions/1547#discussioncomment-5021002