### PR TITLE
アクセサプロパティをアクセッサプロパティへと統一するように修正した

### DIFF
--- a/source/basic/class/README.md
+++ b/source/basic/class/README.md
@@ -763,8 +763,7 @@ privateExample.dump();
 ```
 
 もう少し具体的なPrivateクラスフィールドの使い方を見ていきます。
-
-アクセサプロパティの例でも登場した`NumberWrapper`をPrivateクラスフィールドを使って書き直してみます。
+アクセッサプロパティの例でも登場した`NumberWrapper`をPrivateクラスフィールドを使って書き直してみます。
 元々の`NumberWrapper`クラスでは、`_value`プロパティに実際の値を読み書きしていました。
 この場合、`_value`プロパティは、外からもアクセスできてしまうため、定義したgetterとsetterが無視できてしまいます。
 


### PR DESCRIPTION
クラスの[Privateクラスフィールド](https://jsprimer.net/basic/class/#private-class-fields)の項にて、一箇所「アクセサプロパティ」という記述があったため、その箇所以外で使われている「アクセッサプロパティ」へと統一するよう修正しました。ご検討ください。