### PR TITLE
fix: 「ECMAScriptモジュール」において console.log の内容が誤っている箇所を修正

### DIFF
--- a/source/basic/module/src/named-import.js
+++ b/source/basic/module/src/named-import.js
@@ -1,4 +1,4 @@
 // 名前つきエクスポートされたfooとbarをインポートする
 import { foo, bar } from "./my-module.js";
 console.log(foo); // => "foo"
-console.log(bar); // => "bar"
+console.log(bar); // => "function bar()"


### PR DESCRIPTION
https://jsprimer.net/basic/module/#named-export-import において、my-module.js の内容が

```js
export const foo = "foo";
export function bar() { }
```

となっているにも関わらず、そこから名前付きインポートした bar を console.log した出力が `"bar"` となっていたため、Firefox で bar 関数を console.log した際の出力内容に修正しました。