### PR TITLE
fix: 「エントリーポイント」におけるコメント内の不要スペースを削除

### DIFF
--- a/source/use-case/ajaxapp/entrypoint/README.md
+++ b/source/use-case/ajaxapp/entrypoint/README.md
@@ -55,7 +55,7 @@ ajaxapp
 まだ`npx`コマンドの用意ができていなければ、先に「[アプリケーション開発の準備][]」の章を参照してください。
 
 ```shell
-# cdコマンドで ajaxapp/ディレクトリに移動する
+# cdコマンドでajaxapp/ディレクトリに移動する
 $ cd ajaxapp/
 # ajaxapp/をルートにしたローカルサーバーを起動する
 $ npx --yes @js-primer/local-server


### PR DESCRIPTION
かなり細かい話ですが、「エントリーポイント」https://jsprimer.net/use-case/ajaxapp/entrypoint/ において不要なスペースがコメントに含まれている箇所を見つけたため、一応削除しておきました。