### PR TITLE
アクセッサプロパティとBigIntを表記揺れの辞書に追加した

### DIFF
--- a/prh.yml
+++ b/prh.yml
@@ -321,6 +321,10 @@ rules:
         to  : 32ビット整数
       - from: BitBucket
         to  : BitBucket
+  - expected: BigInt
+  - expected: アクセッサプロパティ
+    pattern:
+      - アクセサプロパティ
   # 一致とマッチ
   ## 一致は ===
   - expected: $1一致


### PR DESCRIPTION
- Issue #1611 
- refs: #1608, #1610

アクセッサプロパティとBigIntを表記揺れの辞書に追加しました。
追加する場所等わからなかったので任意の場所に差し込んでいます。不適切な場合、ご指摘ください:bow: