### PR TITLE
Array.prototype.lengthをアクセッサプロパティで再現するのサンプルコードをリファクタリングした

### DIFF
--- a/source/basic/class/README.md
+++ b/source/basic/class/README.md
@@ -456,7 +456,7 @@ class ArrayLike {
     }
 
     set length(newLength) {
-        const currentItemLength = this.items.length;
+        const currentItemLength = this.length;
         // 現在要素数より小さな`newLength`が指定された場合、指定した要素数となるように末尾を削除する
         if (newLength < currentItemLength) {
             this._items = this.items.slice(0, newLength);

--- a/source/basic/class/example/ArrayLike.js
+++ b/source/basic/class/example/ArrayLike.js
@@ -15,7 +15,7 @@ class ArrayLike {
     }
 
     set length(newLength) {
-        const currentItemLength = this.items.length;
+        const currentItemLength = this.length;
         // 現在要素数より小さな`newLength`が指定された場合、指定した要素数となるように末尾を削除する
         if (newLength < currentItemLength) {
             this._items = this.items.slice(0, newLength);


### PR DESCRIPTION
クラスのArray-likeオブジェクトの項(https://jsprimer.net/basic/class/#array-like-length)で
`this.items.length`の部分はthis(ArrayLikeクラスのインスタンス)にgetterのlengthが生えているため、可読性を考慮して`this.length`に変更しました。

ご検討ください。