### PR TITLE
fix: update power-doctest and remove vm2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
         "@jxa/global-type": "^1.3.6",
         "@jxa/run": "^1.3.6",
         "@microsoft/eslint-formatter-sarif": "^3.0.0",
-        "@power-doctest/javascript": "^5.3.1",
-        "@power-doctest/markdown": "^5.3.2",
-        "@power-doctest/tester": "^5.3.2",
+        "@power-doctest/javascript": "^5.3.3",
+        "@power-doctest/markdown": "^5.3.3",
+        "@power-doctest/tester": "^5.3.3",
         "@textlint-ja/textlint-rule-no-synonyms": "^1.3.0",
         "@textlint-rule/textlint-rule-require-header-id": "^1.0.1",
         "@textlint/regexp-string-matcher": "^2.0.2",
@@ -81,7 +81,6 @@
         "unist-util-find-before": "^2.0.5",
         "unist-util-parents": "^1.0.3",
         "unist-util-select": "^3.0.4",
-        "vm2": "^3.9.18",
         "wait-on": "^6.0.1",
         "workbox-cli": "^3.6.3"
       }
@@ -2087,9 +2086,9 @@
       }
     },
     "node_modules/@power-doctest/core": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@power-doctest/core/-/core-5.3.2.tgz",
-      "integrity": "sha512-NjQSHnS4jLODz8nGZd8yOThLkIIgXRLaFrfh9c+rxxQA+EKxnPdWx/GfbvpSOTkYK9+QRcjSKQO+4+ZZG2BhmA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@power-doctest/core/-/core-5.3.3.tgz",
+      "integrity": "sha512-tLKaEZ4lv7WkQG5Y5tVuZWmXGKN7TDxlDHe0NC4NFB69UMXmwHG9Fb/gZbGGKFqYWN+sSe6DBvPs8QM7sB7vPw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -2098,37 +2097,57 @@
         "@babel/traverse": "^7.16.7",
         "@babel/types": "^7.16.7",
         "babel-plugin-espower": "^3.0.1",
-        "comment-to-assert": "^5.3.1",
+        "comment-to-assert": "^5.3.3",
         "espower": "^2.1.2",
         "power-assert": "^1.6.1"
       }
     },
     "node_modules/@power-doctest/javascript": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@power-doctest/javascript/-/javascript-5.3.1.tgz",
-      "integrity": "sha512-isGW0iAFNelASn1Wmtdz0q/8C9UiSOT+scL6j6Tb7RxkAkmT038RCHEHcGgRxCMvBeuBAlLVHozDkPzsO5zEGg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@power-doctest/javascript/-/javascript-5.3.3.tgz",
+      "integrity": "sha512-u/XmauoXLN1sj64kmOBXVCdjMryPIH3CSqo1dnQ3ReEq9sU6FUi1xV715xvpCBPcI8UFjCb5ckms4S+inDHaew==",
       "dev": true,
       "dependencies": {
-        "@power-doctest/types": "^5.3.1",
-        "@types/structured-source": "^3.0.0",
-        "structured-source": "^3.0.2"
+        "@power-doctest/types": "^5.3.3",
+        "structured-source": "^4.0.0"
+      }
+    },
+    "node_modules/@power-doctest/javascript/node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true
+    },
+    "node_modules/@power-doctest/javascript/node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
+      "dependencies": {
+        "boundary": "^2.0.0"
       }
     },
     "node_modules/@power-doctest/markdown": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@power-doctest/markdown/-/markdown-5.3.2.tgz",
-      "integrity": "sha512-SqKBREWJj1IKNhkDLQhpGEnxkRRcKa7Ir/uDvxxR5msFfQZeM/urrHcu7UcYfrGyc1irllZjMAg+oCV1R9yGqw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@power-doctest/markdown/-/markdown-5.3.3.tgz",
+      "integrity": "sha512-YyDJyl6LJz4SWT7RMaRj4y0NXReXUJKk70tYDGijLStMPQK3iYL4jpS44sBdG04f2aZZV7JN4t1Wn7YbfbpabQ==",
       "dev": true,
       "dependencies": {
-        "@power-doctest/javascript": "^5.3.1",
-        "@power-doctest/types": "^5.3.1",
-        "@types/unist": "^2.0.6",
-        "remark": "^11.0.1",
+        "@power-doctest/javascript": "^5.3.3",
+        "@power-doctest/types": "^5.3.3",
+        "@types/unist": "^3.0.0",
+        "remark": "^11.0.2",
         "unist-util-find-all-between": "^1.0.6",
         "unist-util-find-before": "^2.0.4",
         "unist-util-parents": "^1.0.2",
         "unist-util-select": "^2.0.2"
       }
+    },
+    "node_modules/@power-doctest/markdown/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+      "dev": true
     },
     "node_modules/@power-doctest/markdown/node_modules/is-buffer": {
       "version": "2.0.5",
@@ -2335,6 +2354,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@power-doctest/markdown/node_modules/unist-util-stringify-position/node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
+    },
     "node_modules/@power-doctest/markdown/node_modules/unist-util-visit": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
@@ -2389,22 +2414,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@power-doctest/markdown/node_modules/vfile-message/node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
+    },
+    "node_modules/@power-doctest/markdown/node_modules/vfile/node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
+    },
     "node_modules/@power-doctest/tester": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@power-doctest/tester/-/tester-5.3.2.tgz",
-      "integrity": "sha512-TZKSkrQT5ljf+z9Vuoy8RdjRDLp8v0wFSNwnenqIl2Owt6ZwHjWZl/QqaKuHVqI0iICqPkgIUqLroaqmY0qEPg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@power-doctest/tester/-/tester-5.3.3.tgz",
+      "integrity": "sha512-TyuZ3XhZ1OaeAvvG+VwBsDiPghEQPk46+T18ox1B8eNHuKNBXZBlVuTWJBCy4UDQ0pYJSjd0Jj8RArZxDqTOcw==",
       "dev": true,
       "dependencies": {
-        "@power-doctest/core": "^5.3.2",
-        "@power-doctest/types": "^5.3.1",
-        "power-assert": "^1.6.1",
-        "vm2": "^3.9.3"
+        "@power-doctest/core": "^5.3.3",
+        "@power-doctest/types": "^5.3.3",
+        "power-assert": "^1.6.1"
       }
     },
     "node_modules/@power-doctest/types": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@power-doctest/types/-/types-5.3.1.tgz",
-      "integrity": "sha512-fZFVFZ0K0USj7XLUyvf7D63yJxXIhq2lkiJ+wukTciOpVmqQdsyIyGif9ZZYLF3Cnc6JpDwgkD6siyilyYox4Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@power-doctest/types/-/types-5.3.3.tgz",
+      "integrity": "sha512-x9HETox7FWwF92+lHVRjvKUyXvNTBCSBQJWIqwF0mGKJNuEF/VIJ06kd3i9ikvkGUuCQkBKlwQcdQRZGcz1pgQ==",
       "dev": true
     },
     "node_modules/@sideway/address": {
@@ -5486,9 +5522,9 @@
       "dev": true
     },
     "node_modules/comment-to-assert": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/comment-to-assert/-/comment-to-assert-5.3.1.tgz",
-      "integrity": "sha512-bc7Rlilph3WUuYHiTjiAQcyvu+26gYfPMDeebHzw71TLQMD+UCrXn8n6B8aNHCqFawnxDWGGhCxjPI2bCfFpSg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/comment-to-assert/-/comment-to-assert-5.3.3.tgz",
+      "integrity": "sha512-XiHwBAFcZDJ2CuaJmBU0pdkT9yV4CuugqPeWLx2anlYG6r5FhfXETbTUFlTVAUfe3cGXNbaQj/hDV6qGT8Oi5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -19828,22 +19864,6 @@
       "dev": true,
       "dependencies": {
         "unist-util-stringify-position": "^1.1.1"
-      }
-    },
-    "node_modules/vm2": {
-      "version": "3.9.18",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.18.tgz",
-      "integrity": "sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "@jxa/global-type": "^1.3.6",
     "@jxa/run": "^1.3.6",
     "@microsoft/eslint-formatter-sarif": "^3.0.0",
-    "@power-doctest/javascript": "^5.3.1",
-    "@power-doctest/markdown": "^5.3.2",
-    "@power-doctest/tester": "^5.3.2",
+    "@power-doctest/javascript": "^5.3.3",
+    "@power-doctest/markdown": "^5.3.3",
+    "@power-doctest/tester": "^5.3.3",
     "@textlint-ja/textlint-rule-no-synonyms": "^1.3.0",
     "@textlint-rule/textlint-rule-require-header-id": "^1.0.1",
     "@textlint/regexp-string-matcher": "^2.0.2",
@@ -121,7 +121,6 @@
     "unist-util-find-before": "^2.0.5",
     "unist-util-parents": "^1.0.3",
     "unist-util-select": "^3.0.4",
-    "vm2": "^3.9.18",
     "wait-on": "^6.0.1",
     "workbox-cli": "^3.6.3"
   }

--- a/test/lib/testing-code.js
+++ b/test/lib/testing-code.js
@@ -1,5 +1,6 @@
-import { NodeVM } from "vm2";
+import vm from "vm";
 import makeConsoleMock from "consolemock";
+
 /**
  * 次のコメントが実際に実行されないことをテストできるように変換する
  *
@@ -75,14 +76,22 @@ export const toTestCode = (code) => {
  * @param {string} filePath
  */
 export const runTestCode = (code, filePath) => {
-    // Run Test Code
-    const vm = new NodeVM({
-        require: {
-            external: true,
-            context: {
-                console: !!process.env.ENABLE_CONSOLE ? console : makeConsoleMock()
-            }
-        }
+    const script = vm.Script(code, { filename: filePath });
+    const HostBuildIns = Object.freeze({
+        __proto__: null,
+        version: parseInt(process.versions.node.split(".")[0]),
+        require,
+        process,
+        console,
+        setTimeout,
+        setInterval,
+        setImmediate,
+        clearTimeout,
+        clearInterval,
+        clearImmediate,
     });
-    vm.run(code, filePath);
+    script.runInNewContext({
+        ...HostBuildIns,
+        console: !!process.env.ENABLE_CONSOLE ? console : makeConsoleMock()
+    });
 };


### PR DESCRIPTION
`vm2` is discontinue.

- https://github.com/advisories/GHSA-cchq-frgv-rjh5
- https://github.com/patriksimek/vm2/issues/533

Update power-doctest and Use `vm` instead of `vm2`.

- https://github.com/azu/power-doctest/releases/tag/v5.3.3

📝 Sandbox feature is unnessary on our usecase.