### PR TITLE
fix(operator): 「文字列結合演算子」の階層レベルを前後と揃える

### DIFF
--- a/source/basic/operator/README.md
+++ b/source/basic/operator/README.md
@@ -68,7 +68,7 @@ JavaScriptでは、数値は内部的にIEEE 754方式の浮動小数点数と�
 console.log(10 + 0.5); // => 10.5
 ```
 
-## 文字列結合演算子（`+`） {#string-combination-operator}
+### 文字列結合演算子（`+`） {#string-combination-operator}
 
 数値の加算に利用したプラス演算子（`+`）は、文字列の結合に利用できます。
 


### PR DESCRIPTION
「文字列結合演算子」は「二項演算子」のセクション内だと考えられ、また前後の階層レベルが `###` なのでそれと合わせました。

before:
![image](https://github.com/asciidwango/js-primer/assets/1730234/17deaf4e-4065-4909-9344-e1c4a0db67cd)

after:
![image](https://github.com/asciidwango/js-primer/assets/1730234/5783fd97-b0e5-4370-ae89-3d2a8f9a185d)
