### PR TITLE
fix: Node.js の日本語版ページがリンク切れのためリンク先を英語版ページに変更

### DIFF
--- a/source/use-case/nodecli/argument-parse/README.md
+++ b/source/use-case/nodecli/argument-parse/README.md
@@ -208,7 +208,7 @@ SyntaxError: Cannot use import statement outside a module
 [npm]: https://www.npmjs.com/
 [npmのGitHubリポジトリ]: https://github.com/npm/npm
 [CommonJSモジュール]: https://nodejs.org/docs/latest/api/modules.html
-[Node.js]: https://nodejs.org/ja/
+[Node.js]: https://nodejs.org/
 [アプリケーション開発の準備]: ../../setup-local-env/README.md
 [ECMAScriptモジュール]: ../../../basic/module/README.md
 [^1]: --saveオプションをつけてインストールしたのと同じ意味。npm 5.0.0からは--saveがデフォルトオプションとなりました。

--- a/source/use-case/setup-local-env/README.md
+++ b/source/use-case/setup-local-env/README.md
@@ -202,7 +202,7 @@ $ npx --yes @js-primer/local-server --port 8000
 npmでは、すでに多種多様なローカルサーバーモジュールが公開されています。
 この書籍では、利用するローカルサーバーの機能で違いが出ないように`@js-primer/local-server`というこの書籍用のローカルサーバーモジュールを利用します。
 
-[Node.js]: https://nodejs.org/ja/
+[Node.js]: https://nodejs.org/
 [V8]: https://v8.dev/
 [Electron]: https://www.electronjs.org/
 [ダウンロードページ]: https://nodejs.org/ja/download/


### PR DESCRIPTION
- Node.js の日本語版ページ https://nodejs.org/ja/が404を返すため、英語版ページ https://nodejs.org/ へのリンクに変更しました