### PR TITLE
feat: ES2020のDynamic Importを追加

### DIFF
--- a/source/basic/module/README.md
+++ b/source/basic/module/README.md
@@ -158,6 +158,66 @@ ECMAScriptモジュールには名前つきとデフォルト以外にもいく�
 
 [import, importExample.js](src/import-side-effects.js)
 
+#### [ES2020] Dynamic Import {#dynamic-import}
+
+Dynamic Importとは、ES2020で追加された、実行時に動的にモジュールをインポートできる機能です。
+通常の`import`文は静的に解析されるため、ファイルの先頭で書く必要があり、条件分岐の中でモジュールをインポートすることはできません。
+
+Dynamic Importを使うと、ユーザーがボタンをクリックしたときのみ機能を読み込んだり、大きなライブラリを必要になったタイミングで読み込んだりなどが可能になります。
+
+Dynamic Importは、`import()`演算子という関数呼び出しによく似た構文を使って行います。
+この関数はPromiseを返すため、`.then()`メソッドや`async`/`await`構文と組み合わせて使います。
+
+次の例では、条件に応じて異なるモジュールを動的にインポートしています。
+
+[import, title="math-utils.js"](src/math-utils.js)
+
+```js
+// 条件分岐でモジュールを動的にインポート
+const condition = true;
+
+if (condition) {
+    import('./math-utils.js')
+        .then((module) => {
+            // インポートしたモジュールを使用
+            console.log(module.add(1, 2));
+        })
+}
+```
+
+また、Top-Level Awaitと組み合わせることで、より簡潔に書くこともできます。
+
+<!-- doctest:disable -->
+```js
+// async関数内でawaitを使用
+async function loadModule() {
+    try {
+        const module = await import('./math-utils.js');
+        console.log(module.add(1, 2)); // => 3
+    } catch (error) {
+        console.error(error);
+    }
+}
+```
+
+<!-- doctest:disable -->
+```js
+// ES2022のTop-Level Awaitを使用（モジュールのトップレベルで直接await）
+const module = await import('./math-utils.js');
+console.log(module.add(1, 2)); // => 3
+```
+
+Dynamic Importで読み込まれたモジュールは、通常のインポートと同じように名前つきエクスポートやデフォルトエクスポートにアクセスできます。
+
+<!-- doctest:disable -->
+```js
+const module = await import('./my-module.js');
+// デフォルトエクスポートにアクセス
+const defaultValue = module.default;
+// 名前つきエクスポートにアクセス
+const { namedExport } = module;
+```
+
 #### [ES2025] インポート属性 {#import-attributes}
 
 インポート属性（Import attributes）とは、モジュールをインポートするときに追加の属性情報を指定できる、ES2025で追加された構文です。インポートするモジュールに関する情報をコード上に明示でき、読み込み方法を制御できます。

--- a/source/basic/module/README.md
+++ b/source/basic/module/README.md
@@ -230,6 +230,13 @@ const { namedExport } = module;
 
 [import, title="main.js"](src/import-attributes.js)
 
+また、Dynamic Importでも、第二引数で同様に属性オブジェクトの指定が可能です。
+
+<!-- doctest:disable -->
+```js
+const jsonData = await import("./data.json", { with: { type: "json" } });
+```
+
 実行環境によってサポートしているインポート属性の`type`は異なりますが、ブラウザではJSON以外にCSSなどもサポートしています。
 
 ## ECMAScriptモジュールを実行する {#run-es-modules}

--- a/source/basic/module/src/math-utils.js
+++ b/source/basic/module/src/math-utils.js
@@ -1,0 +1,1 @@
+export const add = (a, b) => a + b;


### PR DESCRIPTION
close https://github.com/asciidwango/js-primer/issues/1792

## 変更点

- ES2020のDynamic Importを追加
- ES2025のインポート属性に動的インポートでの属性オブジェクトの指定方法を追加