### PR TITLE
chore: unist-util-select を v3→v5 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "textlint-rule-static-method-syntax": "workspace:textlint-rule-static-method-syntax",
         "textstat": "^0.8.0",
         "typescript": "^5.8.3",
-        "unist-util-select": "^3.0.4",
+        "unist-util-select": "^5.1.0",
         "wait-on": "^8.0.3"
       }
     },
@@ -19837,21 +19837,49 @@
       }
     },
     "node_modules/unist-util-select": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.4.tgz",
-      "integrity": "sha512-xf1zCu4okgPqGLdhCDpRnjwBNyv3EqjiXRUbz2SdK1+qnLMB7uXXajfzuBvvbHoQ+JLyp4AEbFCGndmc6S72sw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css-selector-parser": "^1.0.0",
-        "not": "^0.1.0",
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
         "nth-check": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "zwitch": "^1.0.0"
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select/node_modules/css-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-WfUcL99xWDs7b3eZPoRszWVfbNo8ErCF15PTvVROjkShGlAfjIkG6hlfj/sl6/rfo5Q9x9ryJ3VqVnAZDA+gcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/unist-util-select/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/unist-util-stringify-position": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "textlint-rule-static-method-syntax": "workspace:textlint-rule-static-method-syntax",
     "textstat": "^0.8.0",
     "typescript": "^5.8.3",
-    "unist-util-select": "^3.0.4",
+    "unist-util-select": "^5.1.0",
     "wait-on": "^8.0.3"
   }
 }


### PR DESCRIPTION
unist-util-select を v3→v5 にアップデート
- <https://github.com/syntax-tree/unist-util-select/releases>