### PR TITLE
chore: globby を v11 → v14 へアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "gitbook-plugin-js-console": "^3.2.0",
         "gitbook-plugin-page-toc-button": "^0.1.1",
         "gitbook-summary-to-path": "^2.0.0",
-        "globby": "^11.0.4",
+        "globby": "^14.1.0",
         "honkit": "^6.0.2",
         "honkit-plugin-sandpack": "^1.4.0",
         "js-levenshtein": "^1.1.6",
@@ -2958,6 +2958,19 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@textlint-ja/textlint-rule-no-synonyms": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-no-synonyms/-/textlint-rule-no-synonyms-1.3.0.tgz",
@@ -4819,16 +4832,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -6456,19 +6459,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/direction": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
@@ -7669,9 +7659,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7679,7 +7669,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -8715,24 +8705,34 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gopd": {
@@ -13691,13 +13691,16 @@
       "license": "MIT"
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picocolors": {
@@ -15820,13 +15823,16 @@
       "license": "ISC"
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slice-ansi": {
@@ -19707,6 +19713,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "gitbook-plugin-js-console": "^3.2.0",
     "gitbook-plugin-page-toc-button": "^0.1.1",
     "gitbook-summary-to-path": "^2.0.0",
-    "globby": "^11.0.4",
+    "globby": "^14.1.0",
     "honkit": "^6.0.2",
     "honkit-plugin-sandpack": "^1.4.0",
     "js-levenshtein": "^1.1.6",

--- a/test/example-doc-test.js
+++ b/test/example-doc-test.js
@@ -1,4 +1,4 @@
-import globby from "globby";
+import { globbySync } from "globby";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "@power-doctest/tester";
@@ -19,7 +19,7 @@ const sourceDir = path.join(__dirname, "..", "source");
  * Note: ESMには対応していない
  **/
 describe("example:js", function() {
-    const files = globby.sync([
+    const files = globbySync([
         `${sourceDir}/**/*-example.js`, // *-example.js
         `${sourceDir}/**/*.example.js`, // *.example.js
         `${sourceDir}/**/example/*.js`, // example/*.js

--- a/test/example-es-test.js
+++ b/test/example-es-test.js
@@ -1,4 +1,4 @@
-import globby from "globby";
+import { globbySync } from "globby";
 import path from "node:path";
 import url from "node:url";
 
@@ -11,7 +11,7 @@ const sourceDir = path.join(__dirname, "..", "source");
  * Note: ESMには対応していない
  **/
 describe("example:es", function() {
-    const esmFiles = globby.sync([
+    const esmFiles = globbySync([
         `${sourceDir}/use-case/todoapp/**/*-example.js`, // *-example.js
         `${sourceDir}/use-case/todoapp/**/*.example.js`, // *.example.js
         `${sourceDir}/use-case/nodecli/**/example/**/*.js`,

--- a/test/front-matter-test.js
+++ b/test/front-matter-test.js
@@ -3,14 +3,14 @@
 import fs from "node:fs";
 import assert from "node:assert";
 import path from "node:path";
-import globby from "globby";
+import { globbySync } from "globby";
 import parseFrontMatter from "front-matter";
 import url from "node:url";
 const __filename__ = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename__);
 const sourceDir = path.join(__dirname, "..", "source");
 describe("front-matter", function() {
-    const files = globby.sync([
+    const files = globbySync([
         `${sourceDir}/**/*.md`,
         `!${sourceDir}/**/node_modules{,/**}`,
         // 目次は除く

--- a/test/invalid-test.js
+++ b/test/invalid-test.js
@@ -1,7 +1,7 @@
 import { runTestCode, toStrictIfNeeded } from "./lib/testing-code.js";
 
 import assert from "node:assert";
-import globby from "globby";
+import { globbySync } from "globby";
 import fs from "node:fs";
 import url from "node:url";
 import path from "node:path";
@@ -12,7 +12,7 @@ const sourceDir = path.join(__dirname, "..", "source");
  * `*-invalid.js` が実行 または パースエラーとなることをテストする
  **/
 describe("invalid:js", function() {
-    const files = globby.sync([
+    const files = globbySync([
         `${sourceDir}/**/*-invalid.js`,
         `${sourceDir}/**/invalid/**/*.js`,
         `!${sourceDir}/**/node_modules{,/**}`

--- a/test/markdown-doc-test.js
+++ b/test/markdown-doc-test.js
@@ -3,7 +3,7 @@
 import { test } from "@power-doctest/tester";
 import { parse } from "@power-doctest/markdown";
 import { toTestCode } from "./lib/testing-code.js";
-import globby from "globby";
+import { globbySync } from "globby";
 import fs from "node:fs";
 import path from "node:path";
 import semver from "semver";
@@ -55,7 +55,7 @@ const IgnoredECMAScriptVersions = (() => {
  * その他詳細は CONTRIBUTING.md を読む
  **/
 describe("doctest:md", function() {
-    const files = globby.sync([
+    const files = globbySync([
         `${sourceDir}/**/*.md`,
         `!${sourceDir}/**/node_modules{,/**}`,
         `!**/OUTLINE.md`

--- a/tools/typo-finder.mjs
+++ b/tools/typo-finder.mjs
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import { remark } from "remark";
-import globby from "globby";
+import { globbySync } from "globby";
 import fs from "fs";
 import path from "path";
 import { selectAll } from "unist-util-select";
@@ -11,7 +11,7 @@ const sourceDir = path.join(import.meta.dirname, "..", "source");
  *
  * Find typo using levenshtein algorithm.
  */
-const files = globby.sync([
+const files = globbySync([
     `${sourceDir}/**/*.md`,
     `!${sourceDir}/**/node_modules{,/**}`,
     `!**/OUTLINE.md`

--- a/tools/update-package-lock.mjs
+++ b/tools/update-package-lock.mjs
@@ -2,7 +2,7 @@
  * Usage: node tools/update-package-lock.mjs
  * Description: This script updates the package-lock.json for aligned with npm version
  */
-import globby from "globby";
+import { globby } from "globby";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";


### PR DESCRIPTION
globby を v11 → v14 へアップデート
- <https://github.com/sindresorhus/globby/releases>
- v11 → v12 のアップデートで default export から named exports に変わったため修正