### PR TITLE
feat: textlintのMCP設定

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "textlint": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "textlint",
+        "--mcp"
+      ],
+      "env": {
+        "TEXTLINT_MCP": "true"
+      }
+    }
+  }
+}

--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -1,84 +1,85 @@
 const IS_LINK_CHECK = !!process.env.LINK_CHECK;
+// TEXTLINT_MCP=true なら、AI向けのルールを有効にする
+const IS_AI_RULE_ENABLED = process.env.TEXTLINT_MCP === "true";
 module.exports = {
-    "filters": {
-        "comments": true,
-        "allowlist": {
-            "allow": [
+    filters: {
+        comments: true,
+        allowlist: {
+            allow: [
                 "/{#[a-z.-]*?}/g",
                 "/{{[a-zA-Z.]*?}}/g",
                 "と考えるかもしれません",
-                "ブラウザーの開発者ツールとは？"
-            ]
-        }
+                "ブラウザーの開発者ツールとは？",
+            ],
+        },
     },
-    "rules": {
+    rules: {
+        "@textlint-ja/preset-ai-writing": IS_AI_RULE_ENABLED,
         "@textlint-ja/no-synonyms": {
-            "allows": ["アプリ", "ウェブアプリ", "極め", "決め"]
+            allows: ["アプリ", "ウェブアプリ", "極め", "決め"],
         },
         // 使っては行けない変数、関数名
         // 詳細: https://github.com/asciidwango/js-primer/issues/804
         "inline-code-denylist": {
-            "denylist": ["string", "number", "object", "boolean", "symbol"]
+            denylist: ["string", "number", "object", "boolean", "symbol"],
         },
         // 静的メソッドの書き方
         "static-method-syntax": true,
         "no-use-column": true,
         "footnote-order": true,
         "no-use-prototype-hash": {
-            "allow": [
+            allow: [
                 // CSSセレクタの表現であるため許可
-                "div#result"
-            ]
+                "div#result",
+            ],
         },
         "@textlint-rule/require-header-id": true,
         // 箇条書きには。を付けない
         "period-in-list-item": {
-            "periodMark": ""
+            periodMark: "",
         },
         "no-js-function-paren": {
-            "allow": [
-                "Symbol"
-            ]
+            allow: ["Symbol"],
         },
         "preset-ja-technical-writing": {
             "no-mix-dearu-desumasu": {
-                "preferInHeader": "",
-                "preferInBody": "ですます",
-                "preferInList": "ですます",
-                "strict": false
+                preferInHeader: "",
+                preferInBody: "ですます",
+                preferInList: "ですます",
+                strict: false,
             },
             "ja-no-redundant-expression": {
-                "dictOptions": {
+                dictOptions: {
                     // "すること[助詞]できる"
                     // https://github.com/textlint-ja/textlint-rule-ja-no-redundant-expression#dict2
-                    "dict2": {
-                        "disabled": true
+                    dict2: {
+                        disabled: true,
                     },
-                    "dict5": {
-                        "allows": [
+                    dict5: {
+                        allows: [
                             "/読み書き/",
                             "/通信/",
                             // デフォルトの許可リストは上書きされるので、維持したい場合は追加する
                             "/^処理を行[ぁ-ん]/",
                             "/^[ァ-ヶ]+を.?行[ぁ-ん]/",
-                            "/^[a-zA-Z]+を.?行[ぁ-ん]/"
-                        ]
-                    }
-                }
+                            "/^[a-zA-Z]+を.?行[ぁ-ん]/",
+                        ],
+                    },
+                },
             },
             "sentence-length": {
-                "max": 95,
-                "skipPatterns": [
+                max: 95,
+                skipPatterns: [
                     // 文末の（...）。はカウントしない
-                    "/（.*?）。$/"
-                ]
+                    "/（.*?）。$/",
+                ],
             },
             "no-exclamation-question-mark": {
-                "allowFullWidthQuestion": true
+                allowFullWidthQuestion: true,
             },
             "max-kanji-continuous-len": {
-                "max": 6,
-                "allow": [
+                max: 6,
+                allow: [
                     "倍精度浮動小数",
                     "浮動小数点数",
                     "排他的論理和",
@@ -91,34 +92,32 @@ module.exports = {
                     "論理和演算子",
                     "排他的論理和演算子",
                     "文字列結合演算子",
-                    "符号化文字集合"
-                ]
+                    "符号化文字集合",
+                ],
             },
             "no-invalid-control-character": {
-                "checkCode": true
-            }
+                checkCode: true,
+            },
         },
-        "eslint": {
-            "configFile": "./eslint.config.mjs"
+        eslint: {
+            configFile: "./eslint.config.mjs",
         },
-        "prh": {
-            "rulePaths": [
-                "prh.yml"
-            ]
+        prh: {
+            rulePaths: ["prh.yml"],
         },
         // npm run textlint-linkでのみ外部URLをチェックする
         "no-dead-link": IS_LINK_CHECK
             ? {
-                "concurrency": 4,
-                "ignore": [
+                concurrency: 4,
+                ignore: [
                     "https://github.com/asciidwango/js-primer/issues/new?*",
                     "ttps://help.github.com/articles/about-pull-requests/", // 言語にリダイレクトがある
                     "https://goo.gl/**",
                     "https://forms.gle/**",
-                    "http://localhost:3000/**"
+                    "http://localhost:3000/**",
                 ],
-                maxRetryAfterTime: 60
+                maxRetryAfterTime: 60,
             }
-            : false
-    }
+            : false,
+    },
 };

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "textlint": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "textlint",
+        "--mcp"
+      ],
+      "env": {
+        "TEXTLINT_MCP": "true"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

iterator-helpersブランチから必要な設定ファイルを移植しました。

## 変更内容

- `.mcp.json`と`.vscode/mcp.json`にtextlint MCPサーバー設定を追加
  - VSCodeでMCP（Model Context Protocol）を使用してtextlintを実行できるようになります
  - `TEXTLINT_MCP=true`環境変数が設定されます
- `.textlintrc.js`にAI向けルール（`@textlint-ja/preset-ai-writing`）を追加
  - `TEXTLINT_MCP=true`環境変数が設定されている場合のみ有効になります

## 動作確認

- [ ] `TEXTLINT_MCP=true npm run textlint` でAI向けルールが有効になることを確認
- [ ] VSCodeでMCP拡張機能が正しく動作することを確認

## 関連

- iterator-helpersブランチで開発されていた設定を移植