### PR TITLE
fix: yshibata.blog.ss-blog.jp のドメインが切れていたので最新のものに更新

### DIFF
--- a/source/intro/feedback/README.md
+++ b/source/intro/feedback/README.md
@@ -56,8 +56,8 @@ GitHubのアカウントを持っていない方は、次のフォームから�
 
 ## 参考 {#reference}
 
-- [専門書には間違いもある：柴田 芳樹 (Yoshiki Shibata)：So-netブログ](https://yshibata.blog.ss-blog.jp/2015-12-23)
-- [技術書の間違いに気付いたら：柴田 芳樹 (Yoshiki Shibata)：So-netブログ](https://yshibata.blog.ss-blog.jp/2018-06-09)
+- [専門書には間違いもある：柴田 芳樹 (Yoshiki Shibata)：So-netブログ](https://yoshikishibata.seesaa.net/article/2015-12-23.html)
+- [技術書の間違いに気付いたら：柴田 芳樹 (Yoshiki Shibata)：So-netブログ](https://yoshikishibata.seesaa.net/article/2018-06-09.html)
 
 [Pull Request]: https://help.github.com/articles/about-pull-requests/
 [CONTRIBUTING.md]: https://github.com/asciidwango/js-primer/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
ss-blog.jpは2025年3月31日に終了したとのことでした。
柴田芳樹（Yoshiki Shibata）さんのブログが以下のドメインに移管されていたので、関連する参考リンクを更新します。

```
before: yshibata.blog.ss-blog.jp
after: yoshikishibata.seesaa.net
```

<img width="619" height="227" alt="スクリーンショット 2025-07-29 23 37 37" src="https://github.com/user-attachments/assets/45e65293-034d-4a6b-9750-734db708dfee" />
