### PR TITLE
fix: Remove Babel dependencies to fix Node.js 24 compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-env"
-  ]
-}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,3 @@
 {
-  "require": [
-    "@babel/register"
-  ],
   "timeout": "10000"
 }

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "textlint/*"
   ],
   "devDependencies": {
-    "@babel/core": "^7.28.0",
-    "@babel/preset-env": "^7.28.0",
-    "@babel/register": "^7.27.1",
     "@eslint/js": "^9.30.1",
     "@jxa/global-type": "^1.4.0",
     "@jxa/run": "^1.4.0",


### PR DESCRIPTION
## Summary
- Node.js 24でテストが失敗する問題を修正
- 不要なBabel関連の依存を削除

## 変更内容
- `.mocharc.json`から`@babel/register`の設定を削除
- `package.json`から以下のBabel関連パッケージを削除：
  - `@babel/core`
  - `@babel/preset-env`
  - `@babel/register`

## 背景
プロジェクトは既にES module形式（`"type": "module"`）に移行済みのため、Babelによるトランスパイルは不要です。

Node.js 24では、ES moduleプロジェクトでCommonJS形式の`require`を使用すると、より厳格なエラーチェックが行われるようになりました。`.mocharc.json`で`@babel/register`をrequireしていたことが原因でテストが失敗していました。

## テスト結果
ローカル環境（Node.js 24.5.0）でテストを実行し、すべてのテストがパスすることを確認しました。

```
ℹ tests 1041
ℹ suites 75
ℹ pass 1041
ℹ fail 0
```

🤖 Generated with [Claude Code](https://claude.ai/code)