### PR TITLE
docs: Update NotebookLM URL

### DIFF
--- a/source/cheatsheet/README.md
+++ b/source/cheatsheet/README.md
@@ -81,7 +81,7 @@ JavaScriptの言語機能に関するチートシートです。
 この書籍の学習を補完するリソースとして、次のNotebookLMのページを用意しています。
 NotebookLMでは、自然言語で書籍について質問もできるので、チートシートと合わせて活用してください。
 
-- [JavaScript Primer - NotebookLM](https://notebooklm.google.com/notebook/99f77ebb-4c13-411d-9474-ec18b2278098)
+- [JavaScript Primer - NotebookLM](https://notebooklm.google.com/notebook/295f7def-145e-4393-9e06-afb4e6e23781)
 
 ## 目次 {#table-of-contents}
 

--- a/source/intro/preparation/README.md
+++ b/source/intro/preparation/README.md
@@ -119,7 +119,7 @@ JavaScriptという言語は、常に変化している言語としても知ら�
 この書籍の学習を補完するリソースとして、次のNotebookLMのページを用意しています。
 NotebookLMでは、自然言語で書籍について質問をしたり、対話しながら学習を進めることができます。
 
-- [JavaScript Primer - NotebookLM](https://notebooklm.google.com/notebook/99f77ebb-4c13-411d-9474-ec18b2278098)
+- [JavaScript Primer - NotebookLM](https://notebooklm.google.com/notebook/295f7def-145e-4393-9e06-afb4e6e23781)
 
 たとえば、NotebookLMは次のような質問をしたりできます。
 


### PR DESCRIPTION
## 概要

JavaScript Primerの学習補助リソースとして提供しているNotebookLMのURLを更新します。

- 旧URL: `https://notebooklm.google.com/notebook/99f77ebb-4c13-411d-9474-ec18b2278098`
- 新URL: `https://notebooklm.google.com/notebook/295f7def-145e-4393-9e06-afb4e6e23781`

ソースが更新できなかったので作り直しました

## 変更内容

### 更新対象ファイル
- `source/cheatsheet/README.md` - チートシートページのNotebookLMリンク
- `source/intro/preparation/README.md` - 準備章のNotebookLMリンク

### 変更理由
NotebookLMのノートブックが新しいIDに移行されたため、書籍内のリンクを更新する必要があります。

## 影響範囲

- ドキュメントの外部リンク更新のみ
- 機能的な変更なし
- 後方互換性への影響なし

## テスト計画

### 手動確認項目
- [ ] 新しいNotebookLMのURLが正しくアクセスできることを確認
- [ ] リンクをクリックして適切なNotebookLMページが表示されることを確認
- [ ] ビルド後のHTMLでリンクが正しく生成されていることを確認

## 関連Issue/PR

なし

## その他

この変更は、読者がJavaScript Primerの学習補助ツールであるNotebookLMに正しくアクセスできるようにするためのメンテナンス更新です。