### PR TITLE
fix(ci): E2EテストのCI失敗を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,26 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
+  e2e-prepare:
+    runs-on: ubuntu-latest
+    name: "E2E prepare"
+    outputs:
+      playwright-version: ${{ steps.playwright-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout: source/use-case/todoapp/package-lock.json
+      - name: Get Playwright version from lockfile
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(JSON.parse(require('fs').readFileSync('source/use-case/todoapp/package-lock.json','utf8')).packages['node_modules/@playwright/test'].version)")" >> "$GITHUB_OUTPUT"
   e2e:
+    needs: e2e-prepare
     runs-on: ubuntu-latest
     name: E2E
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.e2e-prepare.outputs.playwright-version }}-noble
+      options: --init --ipc=host --user=1001
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -55,10 +72,4 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
-      - name: Install todoapp dependencies
-        run: npm install
-        working-directory: ./source/use-case/todoapp
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium
-        working-directory: ./source/use-case/todoapp
       - run: npm run e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,6 @@ jobs:
         run: npm install
         working-directory: ./source/use-case/todoapp
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
         working-directory: ./source/use-case/todoapp
       - run: npm run e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
+      - name: Install todoapp dependencies
+        run: npm install
+        working-directory: ./source/use-case/todoapp
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: ./source/use-case/todoapp

--- a/source/use-case/todoapp/tests/app-structure/todo-html/todo-html.spec.ts
+++ b/source/use-case/todoapp/tests/app-structure/todo-html/todo-html.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { visitWithConsole } from "../../helper/console-helper";
 
 const URL = "/app-structure/todo-html";

--- a/source/use-case/todoapp/tests/entrypoint/first-entry/first-entry.spec.ts
+++ b/source/use-case/todoapp/tests/entrypoint/first-entry/first-entry.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { visitWithConsole } from "../../helper/console-helper";
 
 const URL = "/entrypoint/first-entry";

--- a/source/use-case/todoapp/tests/entrypoint/module-entry/module-entry.spec.ts
+++ b/source/use-case/todoapp/tests/entrypoint/module-entry/module-entry.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { visitWithConsole } from "../../helper/console-helper";
 
 const URL = "/entrypoint/module-entry";

--- a/source/use-case/todoapp/tests/event-model/event-emitter/event-emitter.spec.ts
+++ b/source/use-case/todoapp/tests/event-model/event-emitter/event-emitter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/event-model/event-emitter";

--- a/source/use-case/todoapp/tests/final/final/final.spec.ts
+++ b/source/use-case/todoapp/tests/final/final/final.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/final/final";

--- a/source/use-case/todoapp/tests/final/more/more.spec.ts
+++ b/source/use-case/todoapp/tests/final/more/more.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/final/more";

--- a/source/use-case/todoapp/tests/fixtures.ts
+++ b/source/use-case/todoapp/tests/fixtures.ts
@@ -1,0 +1,37 @@
+import { test as base } from "@playwright/test";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+const TODOAPP_DIR = path.resolve(import.meta.dirname, "..");
+
+/**
+ * jsprimer.netへの外部リクエストをローカルファイルから応答するカスタムテスト
+ * CI環境で外部URLにアクセスできない場合でもテストが動作するようにする
+ */
+export const test = base.extend({
+    page: async ({ page }, use) => {
+        await page.route("https://jsprimer.net/use-case/todoapp/**", async (route) => {
+            const url = new URL(route.request().url());
+            const relativePath = url.pathname.replace(
+                "/use-case/todoapp/",
+                ""
+            );
+            const localFilePath = path.join(TODOAPP_DIR, relativePath);
+            if (fs.existsSync(localFilePath)) {
+                const contentType = localFilePath.endsWith(".css")
+                    ? "text/css"
+                    : "application/octet-stream";
+                await route.fulfill({
+                    status: 200,
+                    contentType,
+                    body: fs.readFileSync(localFilePath),
+                });
+            } else {
+                await route.continue();
+            }
+        });
+        await use(page);
+    },
+});
+
+export { expect } from "@playwright/test";

--- a/source/use-case/todoapp/tests/fixtures.ts
+++ b/source/use-case/todoapp/tests/fixtures.ts
@@ -1,8 +1,10 @@
 import { test as base } from "@playwright/test";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const TODOAPP_DIR = path.resolve(import.meta.dirname, "..");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TODOAPP_DIR = path.resolve(__dirname, "..");
 
 /**
  * jsprimer.netへの外部リクエストをローカルファイルから応答するカスタムテスト

--- a/source/use-case/todoapp/tests/form-event/add-todo-item/add-todo-item.spec.ts
+++ b/source/use-case/todoapp/tests/form-event/add-todo-item/add-todo-item.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/form-event/add-todo-item";

--- a/source/use-case/todoapp/tests/form-event/prevent-event/prevent-event.spec.ts
+++ b/source/use-case/todoapp/tests/form-event/prevent-event/prevent-event.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { visitWithConsole } from "../../helper/console-helper";
 import { addNewTodo } from "../../helper/todo-helper";
 

--- a/source/use-case/todoapp/tests/update-delete/add-checkbox/add-checkbox.spec.ts
+++ b/source/use-case/todoapp/tests/update-delete/add-checkbox/add-checkbox.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/update-delete/add-checkbox";

--- a/source/use-case/todoapp/tests/update-delete/delete-feature/delete-feature.spec.ts
+++ b/source/use-case/todoapp/tests/update-delete/delete-feature/delete-feature.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/update-delete/delete-feature";

--- a/source/use-case/todoapp/tests/update-delete/update-feature/update-feature.spec.ts
+++ b/source/use-case/todoapp/tests/update-delete/update-feature/update-feature.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures";
 import { addNewTodo } from "../../helper/todo-helper";
 
 const URL = "/update-delete/update-feature";


### PR DESCRIPTION
## 概要

E2Eジョブが継続的に失敗していた問題を修正。

## 原因

1. **ブラウザバージョン不一致**: `npx playwright install` が `npm install` 前に実行され、`@playwright/test@1.57.0` が期待するブラウザビルド(v1200)とは異なるビルドがインストールされていた
2. **apt-get失敗**: `--with-deps` が実行する `apt-get update` でGitHub ActionsランナーのMicrosoft aptリポジトリが403を返す
3. **外部CSS依存**: E2EテストがjsprimerのCSSを外部URLから読み込んでおり、CI環境からアクセスできない場合にテストが失敗

## 変更内容

- E2EジョブでPlaywright公式Dockerイメージ(`mcr.microsoft.com/playwright`)を使用するように変更。ブラウザとシステム依存がイメージに同梱済みのため、`playwright install` や `apt-get` が不要
- バージョンは `package-lock.json` から動的に取得し、`@playwright/test` との不一致を防止
- Playwrightのカスタムfixtureを追加し、`https://jsprimer.net` への外部CSSリクエストをローカルファイルから応答するように変更

## テスト

- ローカルで `CI=true npx playwright test` → 14 passed
- `npm test` → 1076 tests passed, 0 failed

https://claude.ai/code/session_01BcNNQTPhWbNGqynZEvAdVz