### PR TITLE
chore(node26): CI環境node26対応

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
         os: [macOS-latest, windows-latest, ubuntu-latest]
     name: "Build on Node.js: ${{ matrix.node-version }} OS: ${{ matrix.os }}"
     steps:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
     name: "Test on Node.js ${{ matrix.node-version }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -70,6 +70,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 24
+          node-version: 26
       - run: npm ci
       - run: npm run e2e

--- a/test/markdown-doc-test.js
+++ b/test/markdown-doc-test.js
@@ -21,29 +21,32 @@ const sourceDir = path.join(__dirname, "..", "source");
  * @type {string[]} サポートしてないECMAScriptバージョン
  */
 const IgnoredECMAScriptVersions = (() => {
-    // https://node.green/#ES2025
-    if (semver.cmp(process.version, ">=", "24.0.0")) {
+    // https://node.green/#ES2026
+    if (semver.cmp(process.version, ">=", "26.0.0")) {
         return []; // すべて通る前提
     }
+    if (semver.cmp(process.version, ">=", "24.0.0")) {
+        return ["2026"]; // Map/WeakMap upsertがサポートされていない
+    }
     if (semver.cmp(process.version, ">=", "22.0.0")) {
-        return ["2025"]; // RegExp Pattern Modifiersは通らない
+        return ["2025", "2026"]; // RegExp Pattern Modifiersは通らない
     }
     if (semver.cmp(process.version, ">=", "20.0.0")) {
-        return ["2024", "2025"]; // Object.groupByがサポートされていない
+        return ["2024", "2025", "2026"]; // Object.groupByがサポートされていない
     }
     if (semver.cmp(process.version, ">=", "18.0.0")) {
-        return ["2023", "2024", "2025"]; // Array.prototype.withがサポートされていない
+        return ["2023", "2024", "2025", "2026"]; // Array.prototype.withがサポートされていない
     }
     if (semver.cmp(process.version, ">=", "16.0.0")) {
         // Array.prototype.findLastIndex をサポートしていない
-        return ["2023", "2024", "2025"];
+        return ["2023", "2024", "2025", "2026"];
     }
     if (semver.cmp(process.version, ">=", "14.0.0")) {
         // String#replaceAll をサポートしていない
         // Top-Level await をサポートしていない
-        return ["2021", "2022", "2023", "2024", "2025"];
+        return ["2021", "2022", "2023", "2024", "2025", "2026"];
     }
-    return ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
+    return ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025", "2026"];
 })();
 
 /**


### PR DESCRIPTION
## Summary

#1885 に付随して、

[actions/node-versionsにnode v26が入った](https://github.com/actions/node-versions/releases/tag/26.0.0-25413736946) ため以下の対応を実施

- CIのmatrixにnode26を追加
- E2Eの実行環境をnode24 -> 26に更新
- サンプルコードテストにES2026バイパス経路を追加

## Tests

環境: node-v26.0.0-darwin-arm64

- [x] `npm test`
- [x] `npm run lint`


actions/setup-nodeや.node-versionは触っていません

漏れあればご指摘下さい