### PR TITLE
docs(es2026): add JSON.rawJSON note for BigInt serialization

### DIFF
--- a/source/basic/json/README.md
+++ b/source/basic/json/README.md
@@ -174,6 +174,8 @@ console.log(JSON.stringify(obj, null, "\t"));
 | Map, Set        |  {}             |
 | BigInt          |  例外が発生する    |
 
+`BigInt`などを扱うには ES2026 の `JSON.rawJSON` を使う必要があります。
+
 {{book.console}}
 ```js
 // 値が関数のプロパティ


### PR DESCRIPTION
Closes #1874

B0 level - 1 line note about `JSON.rawJSON`

Add a note after the non-serializable JSON table mentioning that BigInt handling requires ES2026 `JSON.rawJSON`.

This follows the B0 proposal from the issue:
- Add 1 line: BigIntなどを扱うには ES2026 の JSON.rawJSON を使う必要があります
- No reviver or new section needed

Point value: 1 point ($23)